### PR TITLE
feat: represent the SOCP, its cone product and the sign convention

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -19,9 +19,10 @@ section:
 | `solver` | The iteration itself | `cosa`, `initialization`, `termination` |
 | `experiments` | Numerical studies | `portfolio`, `frontier`, `benchmarks` |
 
-Every package exists now and is empty apart from a docstring naming the modules it will
-own. That is deliberate: it means each later issue has an unambiguous home, and the
-module names above are authoritative even though the files do not exist yet.
+Every package exists, each with a docstring naming the modules it will own. That is
+deliberate: it means each later issue has an unambiguous home, and the module names
+above are authoritative even before the files exist. `problem/socp.py` is the first of
+them to land; the rest are still names.
 
 ## One deviation from the plan: where tests live
 
@@ -78,7 +79,7 @@ is stable. Nothing here forecloses it.
 
 ## Public surface
 
-`cosa/__init__.py` exports exactly two names today:
+`cosa/__init__.py` exports the array aliases every module shares:
 
 ```python
 from cosa import Matrix, Vector
@@ -90,3 +91,13 @@ purpose -- the distinction they carry is for the reader, not for the type checke
 
 The surface is narrow by choice. Each module named in the table above extends `__all__`
 as it lands, rather than reserving names in advance for code that does not exist.
+`problem/socp.py` is the first to do so: it adds `SOCP`, `MeanStdForm`,
+`SecondOrderCone`, `ConeProduct`, `ProblemError`, `SignConvention` and
+`SIGN_CONVENTION`.
+
+## The other decision recorded once
+
+The sign convention for the conic KKT conditions lives on
+[its own page](sign-convention.md), for the same reason this one exists: the plan defers
+it to the implementation, and four later issues consume it. Read it before touching
+multipliers, residuals or the working set.

--- a/docs/development/sign-convention.md
+++ b/docs/development/sign-convention.md
@@ -1,0 +1,158 @@
+# The sign convention
+
+The record of the decision taken in [#9](https://github.com/tschm/cosa/issues/9). The
+project plan defers this one on purpose -- *"The exact sign convention will be fixed in
+the implementation and must be used consistently throughout the derivation and code"* --
+so it is fixed here, once, and every consumer reads it from here rather than choosing
+again.
+
+It matters because four separate pieces of the algorithm consume it: the KKT assembly,
+the multiplier computation and its sign tests, the conic KKT residuals and termination
+criterion, and the conic working-set logic that decides when a cone leaves the working
+set. If each picks its own sign, the multiplier tests agree with nothing and the
+residuals silently disagree with the working-set decisions.
+
+## The problem
+
+`cosa.problem.socp.SOCP` is the general form, of which the plan's eq. (7) is one
+instance:
+
+```text
+min  c.T @ z
+s.t. A @ z <= b
+     E @ z = d
+     G @ z + h in K
+```
+
+`K = Q^(n_1) x ... x Q^(n_J)` is a Cartesian product of second-order cones. Eq. (7) is
+this with `z = (x, t)`, `c = (-mu, lam)`, `G = [[0, 1], [L, 0]]`, `h = 0` and a
+single factor `Q^(1 + k)`.
+
+## The cone, written head first
+
+```text
+Q^n = {(s_0, s_1) in R x R^(n-1) : ||s_1||_2 <= s_0}
+```
+
+The head `s_0` is entry **0**, never the last entry. That ordering is part of the
+convention, not a detail of one function: it is the layout of the conic slack
+`G @ z + h`, of the dual variable `w`, and of every `(head, tail)` pair either is split
+into. `SecondOrderCone.split` and `ConeProduct.split` are the only places that index
+it.
+
+In this representation the second-order cone is self-dual, `K* = K`. There is therefore
+no separate dual-cone type: `w in K` is the dual feasibility condition, which is also
+what the plan asserts (`w_soc in Q`).
+
+## Multipliers and the Lagrangian
+
+`y` for the inequalities, `nu` for the equalities, `w` for the cone:
+
+```text
+Lagr(z, y, nu, w) = c.T @ z + y.T @ (A @ z - b) + nu.T @ (E @ z - d) - w.T @ (G @ z + h)
+```
+
+The conic term is **subtracted**. That is the whole choice, and everything below follows
+from it.
+
+## The KKT conditions
+
+```text
+stationarity            c + A.T @ y + E.T @ nu - G.T @ w = 0
+primal feasibility      A @ z <= b,  E @ z = d,  G @ z + h in K
+dual feasibility        y >= 0,  w in K
+complementarity         y_i * (a_i.T @ z - b_i) = 0
+                        w.T @ (G @ z + h) = 0
+```
+
+Subtracting the conic term is what puts `w` in `K` rather than in `-K`. Adding it
+instead would make dual feasibility read `-w in K`, which contradicts the plan's own
+statement of the condition and would leave every consumer negating a vector before it
+could ask whether it is in the cone.
+
+## What it implies for eq. (7)
+
+In eq. (7) the variable `t` appears only in the objective, with coefficient `lam`, and
+in the head row of `G`. Its stationarity equation is therefore `lam - w_0 = 0`:
+
+```text
+w_0 = lam
+```
+
+The head of the cone multiplier *is* the risk-aversion parameter. This is the
+convention's signature, and the cheapest way to tell whether a consumer has adopted it:
+the opposite choice produces `w_0 = -lam`, which for `lam > 0` is not even in `Q`.
+
+## Where this differs from the plan
+
+The plan's stationarity display writes the conic term with a plus sign,
+`-mu + A.T @ y + E.T @ nu + L.T @ w = 0`, while also asking for `w_soc in Q`. Those two
+cannot both hold for the same `w`: the sign that leaves `w` in the cone is the minus
+sign. The plan is explicit that the display is provisional and the convention is the
+implementation's to fix, and of the two statements the one worth keeping is
+`w_soc in Q`, because self-duality is what the conic complementarity relation and the
+working-set logic are built on. So the sign on `L.T @ w` in that display flips, and
+nothing else in the plan changes.
+
+Where the plan and the code disagree about anything else, treat it as a bug in one of
+them and say so on the issue.
+
+## How to consume it
+
+Two entry points, and no third:
+
+- `SOCP.stationarity_residual(y, nu, w)` for the residual itself.
+- `cosa.SIGN_CONVENTION` for the three signs, when a consumer assembles the terms into
+  something else -- a KKT matrix, a multiplier solve, a warm-start check.
+
+```python
+import numpy as np
+
+from cosa import SIGN_CONVENTION, MeanStdForm
+
+# One asset, mu = 1, lam = 1/2, x <= 1. The bound binds, so x = t = 1, and the KKT
+# conditions give y = 1/2 and w = (1/2, -1/2): the head of w is lam, and w is on the
+# boundary of Q.
+problem = MeanStdForm(
+    mu=np.array([1.0]),
+    lam=0.5,
+    A=np.array([[1.0]]),
+    b=np.array([1.0]),
+    E=np.zeros((0, 1)),
+    d=np.zeros(0),
+    L=np.array([[1.0]]),
+).to_socp()
+
+z = np.array([1.0, 1.0])
+y = np.array([0.5])
+nu = np.zeros(0)
+w = np.array([0.5, -0.5])
+
+assert np.allclose(problem.stationarity_residual(y, nu, w), 0.0)
+assert np.isclose(w @ problem.cone_slack(z), 0.0)
+
+head, tail = problem.cone.split(w)[0]
+assert head == 0.5
+assert np.linalg.norm(tail) <= head
+
+# The same three signs a consumer that assembles its own terms must use.
+assert (SIGN_CONVENTION.inequality, SIGN_CONVENTION.equality, SIGN_CONVENTION.cone) == (1.0, 1.0, -1.0)
+```
+
+## How it is enforced
+
+`tests/test_socp.py` carries two instances solved by hand -- the one above, and a
+two-asset budget-constrained one with a nonzero `nu`. Their multipliers are facts about
+this convention, not recordings of what the code produced, and three tests turn them
+into a gate:
+
+- `test_sign_convention_is_the_one_fixed_convention` pins the three signs, so a
+  consumer that assembles its own terms cannot quietly assemble different ones.
+- `test_the_cone_multiplier_head_is_lambda` pins `w_0 = lam`.
+- `test_flipped_signs_are_not_stationary` negates each block of multipliers in turn and
+  requires that stationarity break. The opposite convention does not also satisfy this
+  one, which is what makes the choice checkable rather than merely written down.
+
+A consumer that adopts the other sign fails at least one of the three. When a later
+issue adds a residual set, a multiplier solve or a working-set rule, it asserts against
+these same instances.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,4 +22,5 @@ nav:
   - Paper: paper/paper.pdf
   - Development:
       - Architecture: development/architecture.md
+      - Sign convention: development/sign-convention.md
       - Rhiza: development/rhiza.md

--- a/src/cosa/__init__.py
+++ b/src/cosa/__init__.py
@@ -8,7 +8,9 @@ constraints have a natural active-set structure and the risk term
 ``sqrt(x.T @ Sigma @ x)`` enters as a second-order cone.
 
 The full project plan lives in ``docs/paper/paper.tex``; the package layout and the
-decisions behind it are recorded in ``docs/development/architecture.md``.
+decisions behind it are recorded in ``docs/development/architecture.md``, and the one
+fixed sign convention for the conic KKT conditions in
+``docs/development/sign-convention.md``.
 
 Subpackages:
     problem: Problem representation (``socp``, ``portfolio``).
@@ -26,10 +28,31 @@ Attributes:
 import numpy as np
 from numpy.typing import NDArray
 
+from cosa.problem.socp import (
+    SIGN_CONVENTION,
+    SOCP,
+    ConeProduct,
+    MeanStdForm,
+    ProblemError,
+    SecondOrderCone,
+    SignConvention,
+)
+
 Vector = NDArray[np.float64]
 Matrix = NDArray[np.float64]
 
-# Deliberately narrow. Nothing else is public yet: every module named in the
-# subpackage list above arrives with its own issue, and each one extends this
-# surface as it lands rather than reserving a name in advance.
-__all__ = ["Matrix", "Vector"]
+# Deliberately narrow: every module named in the subpackage list above extends this
+# surface as it lands, rather than reserving a name in advance for code that does not
+# exist. What is here is the problem representation of `cosa.problem.socp` and the
+# array aliases every module shares.
+__all__ = [
+    "SIGN_CONVENTION",
+    "SOCP",
+    "ConeProduct",
+    "Matrix",
+    "MeanStdForm",
+    "ProblemError",
+    "SecondOrderCone",
+    "SignConvention",
+    "Vector",
+]

--- a/src/cosa/problem/__init__.py
+++ b/src/cosa/problem/__init__.py
@@ -1,9 +1,10 @@
 """Problem representation: the SOCP and the portfolio problem that reduces to it.
 
-Modules (each owned by its own issue):
+Modules:
     socp: The primal SOCP of the paper's eq. (7), with the cone as a Cartesian
-        product of second-order cones, and the one fixed sign convention.
+        product of second-order cones, and the one fixed sign convention. Landed.
     portfolio: The mean-standard-deviation portfolio problem, including the
         factorization ``Sigma = L.T @ L`` that turns the standard deviation into
-        the cone constraint ``||L @ x|| <= t``.
+        the cone constraint ``||L @ x|| <= t``. It produces the
+        ``cosa.problem.socp.MeanStdForm`` this package already defines.
 """

--- a/src/cosa/problem/socp.py
+++ b/src/cosa/problem/socp.py
@@ -1,0 +1,657 @@
+"""The primal SOCP, its cone, and the one fixed sign convention.
+
+The project plan's eq. (7) is the problem COSA solves:
+
+    min  -mu.T @ x + lam * t
+    s.t. A @ x <= b,  E @ x = d,  (t, L @ x) in Q
+
+This module represents it, and represents it in the slightly more general shape the
+plan's "General SOCPs" section targets, because three decisions have to be settled
+here rather than in the issues that consume them.
+
+**The cone is a Cartesian product.** ``K = Q^(n_1) x ... x Q^(n_J)``, even though the
+solver starts by handling a single cone. The general form is
+``min c.T @ z s.t. A @ z <= b, E @ z = d, G @ z + h in K``, which is what the plan's
+generalization section asks for and what makes Success Criterion 7 (modularity)
+reachable without reopening the representation. Eq. (7) is the instance of it with
+``z = (x, t)``, ``c = (-mu, lam)``, ``G = [[0, 1], [L, 0]]`` and ``h = 0``;
+:class:`MeanStdForm` is that instance's data, and it round-trips through
+:meth:`MeanStdForm.to_socp` and :meth:`SOCP.as_mean_std`.
+
+**Auxiliary variables are cheap.** Turnover constraints are expressed with auxiliary
+variables and linear inequalities, so nothing here may assume that the variable vector
+is exactly ``(x, t)``. It is ``z``, of whatever length, and :meth:`SOCP.augment`,
+:meth:`SOCP.add_inequalities`, :meth:`SOCP.add_equalities` and :meth:`SOCP.add_cone`
+grow an instance without rebuilding it.
+
+**The sign convention is fixed here, once.** The plan defers it deliberately -- *"The
+exact sign convention will be fixed in the implementation and must be used consistently
+throughout the derivation and code"* -- so this is that choice. With multipliers
+``y`` for the inequalities, ``nu`` for the equalities and ``w`` for the cone, the
+Lagrangian is
+
+    Lagr(z, y, nu, w) = c.T @ z + y.T @ (A @ z - b) + nu.T @ (E @ z - d)
+                        - w.T @ (G @ z + h)
+
+which makes stationarity
+
+    c + A.T @ y + E.T @ nu - G.T @ w = 0
+
+with ``y >= 0`` and ``w in K``. The cone term is *subtracted*: that is what keeps the
+dual variable in ``K`` itself rather than in ``-K``, and the plan states the dual
+condition as ``w_soc in Q``. The second-order cone is self-dual under the head-first
+representation used here, so ``K* = K`` and no separate dual-cone type exists.
+
+Every consumer reads the signs from :data:`SIGN_CONVENTION` or calls
+:meth:`SOCP.stationarity_residual`; none of them writes the signs out again. The full
+statement, including what it implies for eq. (7) (namely ``w_t = lam``) and where it
+differs from the plan's printed stationarity display, is in
+``docs/development/sign-convention.md``.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from cosa import Matrix, Vector
+
+__all__ = [
+    "SIGN_CONVENTION",
+    "SOCP",
+    "ConeProduct",
+    "MeanStdForm",
+    "ProblemError",
+    "SecondOrderCone",
+    "SignConvention",
+]
+
+
+class ProblemError(ValueError):
+    """The data does not describe a well-formed problem instance.
+
+    A ``ValueError``, because that is what a caller handing over the wrong array
+    shape expects to catch. It is raised for shape disagreement, for a non-finite
+    entry, for an empty problem and for a cone dimension that cannot hold a cone --
+    never for infeasibility, which is the solver's business and not the
+    representation's.
+    """
+
+    def __init__(self, block: str, problem: str) -> None:
+        """Name the block at fault and say what is wrong with it.
+
+        Args:
+            block: the name the offending block goes by in the problem, e.g. ``"A"``.
+            problem: what is wrong with it, phrased as expected-versus-found.
+        """
+        super().__init__(f"{block}: {problem}")
+
+
+def _vector(block: str, value: Vector, *, size: int | None = None) -> Vector:
+    """Coerce a block to a finite one-dimensional float array.
+
+    Args:
+        block: the name the block goes by in the problem, used in error messages.
+        value: the data to coerce.
+        size: the length the instance requires, when it is already determined.
+
+    Returns:
+        A contiguous ``float64`` array of shape ``(size,)``.
+
+    Raises:
+        ProblemError: if the data is not one-dimensional, has the wrong length, or
+            carries a NaN or an infinity.
+    """
+    array = np.array(value, dtype=np.float64, order="C")
+    if array.ndim != 1:
+        raise ProblemError(block, f"expected a vector, found an array of shape {array.shape}")
+    if size is not None and array.size != size:
+        raise ProblemError(block, f"expected {size} entries, found {array.size}")
+    if not np.isfinite(array).all():
+        raise ProblemError(block, "every entry must be finite, found a NaN or an infinity")
+    return array
+
+
+def _matrix(block: str, value: Matrix, *, rows: int | None = None, columns: int | None = None) -> Matrix:
+    """Coerce a block to a finite two-dimensional float array.
+
+    A block with no rows is legitimate: a problem without inequalities carries an
+    ``A`` of shape ``(0, n)``, and the arithmetic works out without a special case.
+
+    Args:
+        block: the name the block goes by in the problem, used in error messages.
+        value: the data to coerce.
+        rows: the number of rows the instance requires, when it is determined.
+        columns: the number of columns the instance requires, when it is determined.
+
+    Returns:
+        A contiguous ``float64`` array of shape ``(rows, columns)``.
+
+    Raises:
+        ProblemError: if the data is not two-dimensional, has the wrong shape, or
+            carries a NaN or an infinity.
+    """
+    array = np.array(value, dtype=np.float64, order="C")
+    if array.ndim != 2:
+        raise ProblemError(block, f"expected a matrix, found an array of shape {array.shape}")
+    if rows is not None and array.shape[0] != rows:
+        raise ProblemError(block, f"expected {rows} rows, found {array.shape[0]}")
+    if columns is not None and array.shape[1] != columns:
+        raise ProblemError(block, f"expected {columns} columns, found {array.shape[1]}")
+    if not np.isfinite(array).all():
+        raise ProblemError(block, "every entry must be finite, found a NaN or an infinity")
+    return array
+
+
+@dataclass(frozen=True)
+class SecondOrderCone:
+    """One second-order cone, written head first.
+
+    ``Q^dim = {(s_0, s_1) in R x R^(dim-1) : ||s_1||_2 <= s_0}``. The head ``s_0`` is
+    entry 0 and the tail ``s_1`` is everything after it -- head first, never head
+    last. That ordering is part of the fixed representation: it is the layout of the
+    primal slack ``G @ z + h``, of the dual variable ``w``, and of anything either of
+    them is split into. The cone is self-dual in this representation, so the same
+    class describes where ``w`` lives.
+
+    Attributes:
+        dim: the total dimension, ``1 + len(tail)``.
+    """
+
+    dim: int
+
+    def __post_init__(self) -> None:
+        """Reject a cone too small to carry both a head and a tail.
+
+        Raises:
+            ProblemError: if ``dim < 2``. ``Q^1`` is the non-negative ray, which is a
+                linear inequality and belongs in ``A @ z <= b``, not in the cone.
+        """
+        if self.dim < 2:
+            raise ProblemError("cone", f"a second-order cone needs a head and a tail, so dim >= 2, found {self.dim}")
+
+    @property
+    def tail_dim(self) -> int:
+        """The length of the tail, ``dim - 1`` -- the ``m`` of the plan's ``Q^(m+1)``."""
+        return self.dim - 1
+
+    def split(self, block: Vector) -> tuple[float, Vector]:
+        """Split a vector in this cone's coordinates into its head and its tail.
+
+        Args:
+            block: a vector of length :attr:`dim`, in this cone's coordinates.
+
+        Returns:
+            The pair ``(head, tail)``, with the head as a scalar.
+        """
+        entries = _vector("cone block", block, size=self.dim)
+        return float(entries[0]), entries[1:]
+
+
+@dataclass(frozen=True)
+class ConeProduct:
+    """The Cartesian product ``K = Q^(n_1) x ... x Q^(n_J)``, in that order.
+
+    The solver starts out handling a single cone, and the plan's generalization
+    section then tracks "the active geometry of multiple cones". Representing the
+    product from the start is what keeps that a matter of extending the working-set
+    logic rather than the problem class.
+
+    The empty product is allowed and means ``K = {0}`` over no rows at all: the
+    instance is then a linear program, which is a useful degenerate case for testing
+    the polyhedral half of the algorithm on its own.
+
+    Attributes:
+        cones: the factors, in the order their blocks appear in ``G @ z + h``.
+    """
+
+    cones: tuple[SecondOrderCone, ...] = ()
+
+    @classmethod
+    def from_dims(cls, *dims: int) -> ConeProduct:
+        """Build the product from its factors' dimensions.
+
+        Args:
+            *dims: one total dimension per factor, each at least 2.
+
+        Returns:
+            The product of the corresponding second-order cones.
+        """
+        return cls(tuple(SecondOrderCone(dim) for dim in dims))
+
+    @property
+    def dim(self) -> int:
+        """The dimension of the product, and so the number of rows of ``G``."""
+        return sum(cone.dim for cone in self.cones)
+
+    @property
+    def slices(self) -> tuple[slice, ...]:
+        """One slice per factor, indexing that factor's block of a product vector."""
+        bounds = tuple(itertools.accumulate((cone.dim for cone in self.cones), initial=0))
+        return tuple(slice(start, stop) for start, stop in itertools.pairwise(bounds))
+
+    def blocks(self, vector: Vector) -> tuple[Vector, ...]:
+        """Cut a product vector into one sub-vector per factor.
+
+        Args:
+            vector: a vector of length :attr:`dim`, e.g. a slack or a dual variable.
+
+        Returns:
+            One view per factor, in factor order.
+        """
+        entries = _vector("cone vector", vector, size=self.dim)
+        return tuple(entries[block] for block in self.slices)
+
+    def split(self, vector: Vector) -> tuple[tuple[float, Vector], ...]:
+        """Cut a product vector into one ``(head, tail)`` pair per factor.
+
+        Args:
+            vector: a vector of length :attr:`dim`, e.g. a slack or a dual variable.
+
+        Returns:
+            One ``(head, tail)`` pair per factor, in factor order.
+        """
+        return tuple(cone.split(block) for cone, block in zip(self.cones, self.blocks(vector), strict=True))
+
+    def __len__(self) -> int:
+        """The number of factors -- one, for the problems the solver starts with."""
+        return len(self.cones)
+
+
+@dataclass(frozen=True)
+class SignConvention:
+    """The sign each dual block carries in the stationarity equation.
+
+    Read from here rather than written out again, so that a consumer assembling a KKT
+    system and a consumer computing a residual cannot drift apart. The single instance
+    is :data:`SIGN_CONVENTION`; the reasoning is in the module docstring and in
+    ``docs/development/sign-convention.md``.
+
+    Attributes:
+        inequality: the sign of ``A.T @ y``, with ``y >= 0`` for ``A @ z <= b``.
+        equality: the sign of ``E.T @ nu``, with ``nu`` free.
+        cone: the sign of ``G.T @ w``, with ``w in K`` for ``G @ z + h in K``.
+    """
+
+    inequality: float
+    equality: float
+    cone: float
+
+
+SIGN_CONVENTION: Final = SignConvention(inequality=1.0, equality=1.0, cone=-1.0)
+"""The one sign convention, fixed once and consumed everywhere."""
+
+
+@dataclass(frozen=True, eq=False, kw_only=True)
+class SOCP:
+    """A second-order cone program, validated on construction.
+
+        min  c.T @ z
+        s.t. A @ z <= b
+             E @ z = d
+             G @ z + h in K
+
+    Every block is required and explicit: a problem with no inequalities carries an
+    ``A`` of shape ``(0, n)`` and a ``b`` of shape ``(0,)``. :meth:`unconstrained`
+    plus the ``add_*`` methods build an instance up a block at a time instead.
+
+    Arrays are copied into contiguous ``float64`` on construction, so an instance does
+    not alias the caller's buffers and no consumer has to defend against an integer
+    dtype. Instances are frozen; every method that changes one returns a new,
+    re-validated instance. Two instances compare by identity rather than block by
+    block, because elementwise array comparison does not answer that question:
+    compare the blocks that matter with ``numpy.testing``.
+
+    Attributes:
+        c: the objective, one entry per variable. Its length defines ``n``.
+        A: the inequality matrix, ``(m_ineq, n)``.
+        b: the inequality right-hand side, ``(m_ineq,)``.
+        E: the equality matrix, ``(m_eq, n)``.
+        d: the equality right-hand side, ``(m_eq,)``.
+        G: the conic matrix, ``(cone.dim, n)``.
+        h: the conic offset, ``(cone.dim,)``.
+        cone: the cone ``K``, as a Cartesian product of second-order cones.
+    """
+
+    c: Vector
+    A: Matrix
+    b: Vector
+    E: Matrix
+    d: Vector
+    G: Matrix
+    h: Vector
+    cone: ConeProduct
+
+    def __post_init__(self) -> None:
+        """Coerce every block and check that the shapes agree with each other.
+
+        Raises:
+            ProblemError: if the objective is empty -- an instance with no variables
+                is not a problem -- or if any block disagrees in shape or carries a
+                non-finite entry.
+        """
+        set_block = object.__setattr__
+        set_block(self, "c", _vector("c", self.c))
+        if self.c.size < 1:
+            raise ProblemError("c", "an instance needs at least one variable, found an empty objective")
+        columns = self.c.size
+        set_block(self, "A", _matrix("A", self.A, columns=columns))
+        set_block(self, "b", _vector("b", self.b, size=self.A.shape[0]))
+        set_block(self, "E", _matrix("E", self.E, columns=columns))
+        set_block(self, "d", _vector("d", self.d, size=self.E.shape[0]))
+        set_block(self, "G", _matrix("G", self.G, rows=self.cone.dim, columns=columns))
+        set_block(self, "h", _vector("h", self.h, size=self.cone.dim))
+
+    @classmethod
+    def unconstrained(cls, c: Vector) -> SOCP:
+        """The objective on its own: no rows anywhere, and the empty cone product.
+
+        The starting point for building an instance incrementally, which is what the
+        generators of auxiliary-variable problems such as turnover want.
+
+        Args:
+            c: the objective, one entry per variable.
+
+        Returns:
+            The instance ``min c.T @ z`` with an empty feasible-set description.
+        """
+        objective = _vector("c", c)
+        return cls(
+            c=objective,
+            A=np.zeros((0, objective.size)),
+            b=np.zeros(0),
+            E=np.zeros((0, objective.size)),
+            d=np.zeros(0),
+            G=np.zeros((0, objective.size)),
+            h=np.zeros(0),
+            cone=ConeProduct(),
+        )
+
+    @property
+    def num_variables(self) -> int:
+        """The length ``n`` of the variable vector ``z``."""
+        return self.c.size
+
+    @property
+    def num_inequalities(self) -> int:
+        """The number of rows of ``A``."""
+        return self.A.shape[0]
+
+    @property
+    def num_equalities(self) -> int:
+        """The number of rows of ``E``."""
+        return self.E.shape[0]
+
+    def cone_slack(self, z: Vector) -> Vector:
+        """The conic slack ``G @ z + h``, the vector the cone membership is about.
+
+        Args:
+            z: a point in variable space.
+
+        Returns:
+            The slack, laid out head first, one block per factor of :attr:`cone`.
+        """
+        return self.G @ _vector("z", z, size=self.num_variables) + self.h
+
+    def stationarity_residual(self, y: Vector, nu: Vector, w: Vector) -> Vector:
+        """The stationarity residual, in the one fixed sign convention.
+
+        ``c + A.T @ y + E.T @ nu - G.T @ w``, with the signs taken from
+        :data:`SIGN_CONVENTION`. This is the definitional home of those signs: the
+        residual set and termination criterion, the multiplier computation and the
+        conic working-set logic all reduce their stationarity check to this, rather
+        than each spelling the signs out.
+
+        The multipliers' own feasibility -- ``y >= 0`` and ``w in K`` -- is not checked
+        here. This is the stationarity block alone.
+
+        Args:
+            y: the inequality multipliers, ``(m_ineq,)``.
+            nu: the equality multipliers, ``(m_eq,)``.
+            w: the conic dual variable, ``(cone.dim,)``.
+
+        Returns:
+            The residual, ``(n,)``. Zero exactly when the point is stationary for
+            these multipliers.
+        """
+        inequality = _vector("y", y, size=self.num_inequalities)
+        equality = _vector("nu", nu, size=self.num_equalities)
+        conic = _vector("w", w, size=self.cone.dim)
+        return (
+            self.c
+            + SIGN_CONVENTION.inequality * (self.A.T @ inequality)
+            + SIGN_CONVENTION.equality * (self.E.T @ equality)
+            + SIGN_CONVENTION.cone * (self.G.T @ conic)
+        )
+
+    def augment(self, columns: int, *, c: Vector | None = None) -> SOCP:
+        """Append fresh variables, zero in every existing row.
+
+        The auxiliary variables of a turnover constraint arrive this way: augment,
+        then add the inequalities that tie the new variables to the old ones.
+
+        Args:
+            columns: how many variables to append.
+            c: their objective coefficients, or ``None`` for variables that do not
+                enter the objective.
+
+        Returns:
+            A new instance with ``columns`` more variables.
+
+        Raises:
+            ProblemError: if ``columns`` is not positive.
+        """
+        if columns < 1:
+            raise ProblemError("columns", f"augmenting adds at least one variable, found {columns}")
+        cost = np.zeros(columns) if c is None else _vector("c", c, size=columns)
+        return replace(
+            self,
+            c=np.concatenate([self.c, cost]),
+            A=np.hstack([self.A, np.zeros((self.num_inequalities, columns))]),
+            E=np.hstack([self.E, np.zeros((self.num_equalities, columns))]),
+            G=np.hstack([self.G, np.zeros((self.cone.dim, columns))]),
+        )
+
+    def add_inequalities(self, rows: Matrix, rhs: Vector) -> SOCP:
+        """Append rows to ``A @ z <= b``.
+
+        Args:
+            rows: the new rows of ``A``, ``(k, n)``.
+            rhs: their right-hand sides, ``(k,)``.
+
+        Returns:
+            A new instance carrying the additional inequalities.
+        """
+        return replace(
+            self,
+            A=np.vstack([self.A, _matrix("new inequality rows", rows, columns=self.num_variables)]),
+            b=np.concatenate([self.b, _vector("new inequality right-hand side", rhs)]),
+        )
+
+    def add_equalities(self, rows: Matrix, rhs: Vector) -> SOCP:
+        """Append rows to ``E @ z = d``.
+
+        Args:
+            rows: the new rows of ``E``, ``(k, n)``.
+            rhs: their right-hand sides, ``(k,)``.
+
+        Returns:
+            A new instance carrying the additional equalities.
+        """
+        return replace(
+            self,
+            E=np.vstack([self.E, _matrix("new equality rows", rows, columns=self.num_variables)]),
+            d=np.concatenate([self.d, _vector("new equality right-hand side", rhs)]),
+        )
+
+    def add_cone(self, cone: SecondOrderCone, rows: Matrix, offset: Vector) -> SOCP:
+        """Append a factor to the cone product, with the rows it constrains.
+
+        Args:
+            cone: the new factor.
+            rows: its rows of ``G``, ``(cone.dim, n)``, head row first.
+            offset: its entries of ``h``, ``(cone.dim,)``, head entry first.
+
+        Returns:
+            A new instance whose cone is the product with one more factor.
+        """
+        return replace(
+            self,
+            G=np.vstack([self.G, _matrix("new cone rows", rows, rows=cone.dim, columns=self.num_variables)]),
+            h=np.concatenate([self.h, _vector("new cone offset", offset, size=cone.dim)]),
+            cone=ConeProduct((*self.cone.cones, cone)),
+        )
+
+    def trivially_infeasible(self) -> str | None:
+        """Why the feasible set is empty by inspection, if it visibly is.
+
+        Only rows that constrain no variable are examined, which is the one kind of
+        emptiness that costs nothing to see and is always a modelling error rather
+        than a hard instance. Everything else -- including conic emptiness, which
+        needs the cone predicates -- is the solver's Phase I to discover.
+
+        Returns:
+            A one-line reason, or ``None`` if nothing is visibly wrong.
+        """
+        empty_rows = ~self.A.any(axis=1)
+        if bool(np.any(self.b[empty_rows] < 0.0)):
+            return "an inequality row constrains no variable and has a negative right-hand side"
+        empty_rows = ~self.E.any(axis=1)
+        if bool(np.any(self.d[empty_rows] != 0.0)):
+            return "an equality row constrains no variable and has a nonzero right-hand side"
+        return None
+
+    def as_mean_std(self) -> MeanStdForm:
+        """Read the instance back as the data of eq. (7).
+
+        The inverse of :meth:`MeanStdForm.to_socp`, and only defined on instances in
+        that shape: one cone, ``t`` as the last variable, ``t`` appearing nowhere but
+        the cone's head row, and ``h = 0``.
+
+        Returns:
+            The eq. (7) data ``mu``, ``lam``, ``A``, ``b``, ``E``, ``d``, ``L``.
+
+        Raises:
+            ProblemError: if the instance is not in the shape of eq. (7).
+        """
+        if len(self.cone) != 1:
+            raise ProblemError("cone", f"eq. (7) has exactly one cone, this instance has {len(self.cone)}")
+        last = self.num_variables - 1
+        head = np.zeros(self.num_variables)
+        head[last] = 1.0
+        reasons = (
+            (bool(np.array_equal(self.G[0], head)), "the cone's head row must select t, the last variable"),
+            (not self.G[1:, last].any(), "t must not appear in the cone's tail rows"),
+            (not self.h.any(), "eq. (7) has no conic offset, so h must be zero"),
+            (not self.A[:, last].any(), "t must not appear in the linear inequalities"),
+            (not self.E[:, last].any(), "t must not appear in the linear equalities"),
+        )
+        for holds, reason in reasons:
+            if not holds:
+                raise ProblemError("instance", f"not in the shape of eq. (7): {reason}")
+        return MeanStdForm(
+            mu=-self.c[:last],
+            lam=float(self.c[last]),
+            A=self.A[:, :last],
+            b=self.b,
+            E=self.E[:, :last],
+            d=self.d,
+            L=self.G[1:, :last],
+        )
+
+
+@dataclass(frozen=True, eq=False, kw_only=True)
+class MeanStdForm:
+    """The data of eq. (7), the mean-standard-deviation SOCP.
+
+        min  -mu.T @ x + lam * t
+        s.t. A @ x <= b
+             E @ x = d
+             (t, L @ x) in Q
+
+    ``L`` is any factor of the covariance with ``Sigma = L.T @ L``, which turns the
+    portfolio standard deviation into ``||L @ x||_2 <= t``. Choosing that factor from
+    a covariance matrix, and generating the portfolio constraints, belong to the
+    portfolio builder; this class is the shape the builder produces and the solver's
+    entry point consumes.
+
+    :meth:`to_socp` maps it into the general :class:`SOCP`, putting ``t`` last and the
+    risk cone as the single factor of the product. :meth:`SOCP.as_mean_std` maps it
+    back, so an instance round-trips.
+
+    Attributes:
+        mu: expected returns, one entry per asset. Its length defines ``n``.
+        lam: the risk-aversion parameter, strictly positive as in the plan.
+        A: the inequality matrix over the assets, ``(m_ineq, n)``.
+        b: the inequality right-hand side, ``(m_ineq,)``.
+        E: the equality matrix over the assets, ``(m_eq, n)``.
+        d: the equality right-hand side, ``(m_eq,)``.
+        L: a factor of the covariance, ``(k, n)`` with ``Sigma = L.T @ L``.
+    """
+
+    mu: Vector
+    lam: float
+    A: Matrix
+    b: Vector
+    E: Matrix
+    d: Vector
+    L: Matrix
+
+    def __post_init__(self) -> None:
+        """Coerce every block and check the shapes against the number of assets.
+
+        Raises:
+            ProblemError: if there are no assets, if ``lam`` is not a positive finite
+                number, or if any block disagrees in shape.
+        """
+        set_block = object.__setattr__
+        set_block(self, "mu", _vector("mu", self.mu))
+        if self.mu.size < 1:
+            raise ProblemError("mu", "an instance needs at least one asset, found an empty mu")
+        set_block(self, "lam", float(self.lam))
+        if not math.isfinite(self.lam) or self.lam <= 0.0:
+            raise ProblemError("lam", f"the plan takes lam > 0, found {self.lam}")
+        assets = self.mu.size
+        set_block(self, "A", _matrix("A", self.A, columns=assets))
+        set_block(self, "b", _vector("b", self.b, size=self.A.shape[0]))
+        set_block(self, "E", _matrix("E", self.E, columns=assets))
+        set_block(self, "d", _vector("d", self.d, size=self.E.shape[0]))
+        set_block(self, "L", _matrix("L", self.L, columns=assets))
+        if self.L.shape[0] < 1:
+            raise ProblemError("L", "a risk term needs at least one row, found a factor with none")
+
+    @property
+    def num_assets(self) -> int:
+        """The number of assets ``n``, the length of ``x``."""
+        return self.mu.size
+
+    def to_socp(self) -> SOCP:
+        """Assemble eq. (7) as a general :class:`SOCP`.
+
+        The variable vector is ``z = (x, t)``, so ``t`` is the last variable and the
+        cone is the single factor ``Q^(1 + k)``, with the head row of ``G`` selecting
+        ``t`` and its tail rows holding ``L``.
+
+        Returns:
+            The instance, validated.
+        """
+        assets = self.num_assets
+        rows = self.L.shape[0]
+        conic = np.zeros((1 + rows, assets + 1))
+        conic[0, assets] = 1.0
+        conic[1:, :assets] = self.L
+        return SOCP(
+            c=np.concatenate([-self.mu, [self.lam]]),
+            A=np.hstack([self.A, np.zeros((self.A.shape[0], 1))]),
+            b=self.b,
+            E=np.hstack([self.E, np.zeros((self.E.shape[0], 1))]),
+            d=self.d,
+            G=conic,
+            h=np.zeros(1 + rows),
+            cone=ConeProduct.from_dims(1 + rows),
+        )

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -26,11 +26,27 @@ def test_subpackage_imports(name):
     assert module.__doc__, f"cosa.{name} has no docstring"
 
 
+# Every name `cosa.__init__` re-exports. The list grows as the modules named in the
+# subpackage docstrings land, and it is spelled out here so that a name arriving or
+# leaving is a deliberate edit to the public surface rather than a side effect.
+PUBLIC_SURFACE = [
+    "SIGN_CONVENTION",
+    "SOCP",
+    "ConeProduct",
+    "Matrix",
+    "MeanStdForm",
+    "ProblemError",
+    "SecondOrderCone",
+    "SignConvention",
+    "Vector",
+]
+
+
 def test_public_surface():
-    """The package exports the shared array aliases and nothing undeclared."""
+    """The package exports the array aliases, the problem representation, and no more."""
     import cosa
 
-    assert cosa.__all__ == ["Matrix", "Vector"]
+    assert cosa.__all__ == PUBLIC_SURFACE
     for name in cosa.__all__:
         assert hasattr(cosa, name), f"cosa.__all__ names {name}, which is missing"
 

--- a/tests/test_socp.py
+++ b/tests/test_socp.py
@@ -1,0 +1,603 @@
+"""The SOCP representation, the cone product, and the fixed sign convention.
+
+The executable half of issue #9. Three things are load-bearing here and are tested
+harder than the rest, because four later issues consume them:
+
+* the cone is a Cartesian product, and its blocks are laid out head first;
+* an instance of eq. (7) round-trips through the general form and back;
+* the sign convention is one convention. The two golden instances at the bottom are
+  hand-solved, so their multipliers pin the signs: a consumer that flips one --
+  computes multipliers of the opposite sign, or assembles a KKT system with `+G.T @ w`
+  -- fails `test_flipped_signs_are_not_stationary` and
+  `test_sign_convention_is_the_one_fixed_convention`.
+"""
+
+import numpy as np
+import pytest
+
+from cosa import (
+    SIGN_CONVENTION,
+    SOCP,
+    ConeProduct,
+    MeanStdForm,
+    ProblemError,
+    SecondOrderCone,
+    SignConvention,
+)
+
+
+@pytest.fixture
+def mean_std():
+    """Eq. (7) with two assets, a budget equality, a box inequality and a full L."""
+    return MeanStdForm(
+        mu=np.array([0.10, 0.04]),
+        lam=2.0,
+        A=np.array([[1.0, 0.0]]),
+        b=np.array([0.7]),
+        E=np.array([[1.0, 1.0]]),
+        d=np.array([1.0]),
+        L=np.array([[0.2, 0.05], [0.0, 0.1]]),
+    )
+
+
+# ----------------------------------------------------------------------------------
+# One cone
+# ----------------------------------------------------------------------------------
+
+
+def test_cone_carries_a_head_and_a_tail():
+    """The plan's Q^(m+1): total dimension, and the m of the tail."""
+    cone = SecondOrderCone(dim=4)
+    assert cone.dim == 4
+    assert cone.tail_dim == 3
+
+
+@pytest.mark.parametrize("dim", [1, 0, -1])
+def test_cone_rejects_a_dimension_below_two(dim):
+    """Q^1 is the non-negative ray, which is a linear inequality, not a cone."""
+    with pytest.raises(ProblemError, match="dim >= 2"):
+        SecondOrderCone(dim=dim)
+
+
+def test_cone_splits_head_first():
+    """Head first, never head last -- the layout every consumer relies on."""
+    head, tail = SecondOrderCone(dim=3).split(np.array([5.0, 3.0, 4.0]))
+    assert head == 5.0
+    np.testing.assert_array_equal(tail, [3.0, 4.0])
+
+
+def test_cone_split_rejects_the_wrong_length():
+    """A block of the wrong length is a bug, not something to broadcast away."""
+    with pytest.raises(ProblemError, match="expected 3 entries"):
+        SecondOrderCone(dim=3).split(np.array([1.0, 2.0]))
+
+
+# ----------------------------------------------------------------------------------
+# The Cartesian product
+# ----------------------------------------------------------------------------------
+
+
+def test_product_of_several_cones():
+    """K = Q^2 x Q^3 x Q^2: the shape the plan's multiple-cone section targets."""
+    product = ConeProduct.from_dims(2, 3, 2)
+    assert len(product) == 3
+    assert product.dim == 7
+    assert product.slices == (slice(0, 2), slice(2, 5), slice(5, 7))
+    assert [cone.dim for cone in product.cones] == [2, 3, 2]
+
+
+def test_product_blocks_partition_a_vector_in_factor_order():
+    """Blocks are consecutive and ordered, so G's rows line up with the factors."""
+    product = ConeProduct.from_dims(2, 3)
+    blocks = product.blocks(np.arange(5.0))
+    np.testing.assert_array_equal(blocks[0], [0.0, 1.0])
+    np.testing.assert_array_equal(blocks[1], [2.0, 3.0, 4.0])
+
+
+def test_product_split_is_a_head_and_tail_per_factor():
+    """The per-factor form the conic working-set logic will iterate over."""
+    pairs = ConeProduct.from_dims(2, 3).split(np.array([1.0, 0.5, 2.0, 1.0, 1.5]))
+    assert pairs[0][0] == 1.0
+    np.testing.assert_array_equal(pairs[0][1], [0.5])
+    assert pairs[1][0] == 2.0
+    np.testing.assert_array_equal(pairs[1][1], [1.0, 1.5])
+
+
+def test_product_rejects_a_vector_of_the_wrong_length():
+    """A dual variable that does not match the cone is caught at the boundary."""
+    with pytest.raises(ProblemError, match="expected 5 entries"):
+        ConeProduct.from_dims(2, 3).blocks(np.zeros(4))
+
+
+def test_empty_product_is_the_linear_program():
+    """No cone at all is allowed: that instance is an LP, which is a useful case."""
+    product = ConeProduct()
+    assert len(product) == 0
+    assert product.dim == 0
+    assert product.slices == ()
+
+
+# ----------------------------------------------------------------------------------
+# The general form and its validation
+# ----------------------------------------------------------------------------------
+
+
+def test_unconstrained_is_the_objective_alone():
+    """The starting point for building an instance up a block at a time."""
+    problem = SOCP.unconstrained(np.array([1.0, 2.0, 3.0]))
+    assert problem.num_variables == 3
+    assert problem.num_inequalities == 0
+    assert problem.num_equalities == 0
+    assert problem.cone.dim == 0
+    assert problem.A.shape == (0, 3)
+    assert problem.G.shape == (0, 3)
+
+
+def test_blocks_are_coerced_to_float_and_copied():
+    """An instance owns its data: integer input is fine, later mutation is not."""
+    objective = np.array([1, 2])
+    problem = SOCP.unconstrained(objective)
+    objective[0] = 99
+    assert problem.c.dtype == np.float64
+    np.testing.assert_array_equal(problem.c, [1.0, 2.0])
+
+
+def test_lists_are_accepted():
+    """Nothing forces a caller to reach for NumPy to write down a small instance."""
+    problem = SOCP.unconstrained([1.0, -1.0]).add_inequalities([[1.0, 1.0]], [2.0])
+    np.testing.assert_array_equal(problem.A, [[1.0, 1.0]])
+    np.testing.assert_array_equal(problem.b, [2.0])
+
+
+def _valid_blocks():
+    """The keyword arguments of a small, valid two-variable instance.
+
+    Returns:
+        A dict of blocks that :class:`SOCP` accepts, for a test to spoil one of.
+    """
+    return {
+        "c": np.array([1.0, 1.0]),
+        "A": np.zeros((1, 2)),
+        "b": np.zeros(1),
+        "E": np.zeros((1, 2)),
+        "d": np.zeros(1),
+        "G": np.eye(2),
+        "h": np.zeros(2),
+        "cone": ConeProduct.from_dims(2),
+    }
+
+
+@pytest.mark.parametrize(
+    ("block", "value", "match"),
+    [
+        ("c", np.zeros(0), "at least one variable"),
+        ("c", np.zeros((2, 1)), "expected a vector"),
+        ("A", np.zeros((1, 3)), "expected 2 columns"),
+        ("A", np.zeros(2), "expected a matrix"),
+        ("b", np.zeros(2), "expected 1 entries"),
+        ("E", np.zeros((1, 5)), "expected 2 columns"),
+        ("d", np.zeros(3), "expected 1 entries"),
+        ("G", np.eye(3), "expected 2 rows"),
+        ("h", np.zeros(1), "expected 2 entries"),
+        ("c", np.array([1.0, np.nan]), "must be finite"),
+        ("G", np.array([[1.0, 0.0], [0.0, np.inf]]), "must be finite"),
+    ],
+)
+def test_validation_catches_a_spoiled_block(block, value, match):
+    """Shape agreement, cone dimension, emptiness and finiteness, all on construction."""
+    blocks = _valid_blocks()
+    blocks[block] = value
+    with pytest.raises(ProblemError, match=match):
+        SOCP(**blocks)
+
+
+def test_cone_dimension_must_match_the_conic_rows():
+    """G's row count is the cone's dimension: the two cannot drift apart."""
+    blocks = _valid_blocks()
+    blocks["cone"] = ConeProduct.from_dims(3)
+    with pytest.raises(ProblemError, match="expected 3 rows"):
+        SOCP(**blocks)
+
+
+def test_cone_slack_is_the_vector_the_cone_is_about():
+    """G @ z + h, laid out head first -- the primal side of the conic condition."""
+    problem = SOCP(**{**_valid_blocks(), "h": np.array([1.0, 2.0])})
+    np.testing.assert_array_equal(problem.cone_slack(np.array([3.0, 4.0])), [4.0, 6.0])
+
+
+# ----------------------------------------------------------------------------------
+# Room for auxiliary variables
+# ----------------------------------------------------------------------------------
+
+
+def test_augment_appends_variables_that_are_zero_everywhere(mean_std):
+    """The turnover pattern: new variables enter no existing row."""
+    problem = mean_std.to_socp()
+    grown = problem.augment(2, c=np.array([0.5, 0.5]))
+    assert grown.num_variables == problem.num_variables + 2
+    np.testing.assert_array_equal(grown.c[-2:], [0.5, 0.5])
+    np.testing.assert_array_equal(grown.A[:, -2:], np.zeros((problem.num_inequalities, 2)))
+    np.testing.assert_array_equal(grown.E[:, -2:], np.zeros((problem.num_equalities, 2)))
+    np.testing.assert_array_equal(grown.G[:, -2:], np.zeros((problem.cone.dim, 2)))
+
+
+def test_augment_defaults_to_variables_outside_the_objective(mean_std):
+    """An auxiliary variable that only appears in constraints costs nothing to add."""
+    grown = mean_std.to_socp().augment(1)
+    assert grown.c[-1] == 0.0
+
+
+def test_augment_needs_at_least_one_variable(mean_std):
+    """Augmenting by nothing is a caller bug, so it says so."""
+    with pytest.raises(ProblemError, match="at least one variable"):
+        mean_std.to_socp().augment(0)
+
+
+def test_turnover_shaped_augmentation(mean_std):
+    """Auxiliary variables plus linear inequalities, the plan's turnover recipe.
+
+    ``|x_i - x_old_i| <= u_i`` becomes two inequalities per asset in the augmented
+    variable vector. The point of the test is that the representation takes it
+    without being reopened.
+    """
+    problem = mean_std.to_socp()
+    assets = mean_std.num_assets
+    grown = problem.augment(assets)
+    previous = np.array([0.5, 0.5])
+    selector = np.zeros((assets, grown.num_variables))
+    selector[:, :assets] = np.eye(assets)
+    bound = np.zeros((assets, grown.num_variables))
+    bound[:, -assets:] = np.eye(assets)
+    turnover = grown.add_inequalities(
+        np.vstack([selector - bound, -selector - bound]),
+        np.concatenate([previous, -previous]),
+    )
+    assert turnover.num_inequalities == problem.num_inequalities + 2 * assets
+    assert turnover.num_variables == assets + 1 + assets
+
+
+def test_add_equalities_appends_rows(mean_std):
+    """The equality block grows the same way, and stays consistent with d."""
+    problem = mean_std.to_socp()
+    grown = problem.add_equalities(np.ones((1, problem.num_variables)), np.array([2.0]))
+    assert grown.num_equalities == problem.num_equalities + 1
+    assert grown.d[-1] == 2.0
+
+
+def test_add_inequalities_rejects_rows_of_the_wrong_width(mean_std):
+    """New rows are checked against the current variable count, not the old one."""
+    problem = mean_std.to_socp().augment(1)
+    with pytest.raises(ProblemError, match="expected 4 columns"):
+        problem.add_inequalities(np.ones((1, 3)), np.array([1.0]))
+
+
+def test_add_cone_grows_the_product(mean_std):
+    """A second cone is an addition to the product, not a new problem class."""
+    problem = mean_std.to_socp()
+    cone = SecondOrderCone(dim=2)
+    rows = np.zeros((2, problem.num_variables))
+    rows[0, -1] = 1.0
+    rows[1, 0] = 1.0
+    grown = problem.add_cone(cone, rows, np.zeros(2))
+    assert len(grown.cone) == 2
+    assert grown.cone.dim == problem.cone.dim + 2
+    assert grown.G.shape == (problem.cone.dim + 2, problem.num_variables)
+
+
+def test_add_cone_rejects_the_wrong_number_of_rows(mean_std):
+    """The new factor's dimension and its rows of G are the same number."""
+    problem = mean_std.to_socp()
+    with pytest.raises(ProblemError, match="expected 2 rows"):
+        problem.add_cone(SecondOrderCone(dim=2), np.zeros((3, problem.num_variables)), np.zeros(2))
+
+
+# ----------------------------------------------------------------------------------
+# Ill-posedness that is visible without solving
+# ----------------------------------------------------------------------------------
+
+
+def test_a_well_posed_instance_is_not_trivially_infeasible(mean_std):
+    """The common case: nothing visibly wrong, and no opinion offered about the rest."""
+    assert mean_std.to_socp().trivially_infeasible() is None
+
+
+def test_an_empty_inequality_row_with_a_negative_bound_is_empty(mean_std):
+    """0 <= -1 constrains nothing and rules out everything."""
+    problem = mean_std.to_socp()
+    spoiled = problem.add_inequalities(np.zeros((1, problem.num_variables)), np.array([-1.0]))
+    assert spoiled.trivially_infeasible() == (
+        "an inequality row constrains no variable and has a negative right-hand side"
+    )
+
+
+def test_an_empty_equality_row_with_a_nonzero_bound_is_empty(mean_std):
+    """0 = 1 is the other half of the same modelling error."""
+    problem = mean_std.to_socp()
+    spoiled = problem.add_equalities(np.zeros((1, problem.num_variables)), np.array([1.0]))
+    assert spoiled.trivially_infeasible() == (
+        "an equality row constrains no variable and has a nonzero right-hand side"
+    )
+
+
+def test_an_empty_row_with_a_consistent_bound_is_only_redundant(mean_std):
+    """0 <= 1 and 0 = 0 are redundant rows, which is not the same as infeasible."""
+    problem = mean_std.to_socp()
+    padded = problem.add_inequalities(np.zeros((1, problem.num_variables)), np.array([1.0]))
+    padded = padded.add_equalities(np.zeros((1, padded.num_variables)), np.array([0.0]))
+    assert padded.trivially_infeasible() is None
+
+
+# ----------------------------------------------------------------------------------
+# Eq. (7) and the round trip
+# ----------------------------------------------------------------------------------
+
+
+def test_mean_std_maps_into_the_general_form(mean_std):
+    """The general form takes z = (x, t), c = (-mu, lam) and one factor Q^(1 + k)."""
+    problem = mean_std.to_socp()
+    assets = mean_std.num_assets
+    assert problem.num_variables == assets + 1
+    np.testing.assert_array_equal(problem.c, [-0.10, -0.04, 2.0])
+    assert len(problem.cone) == 1
+    assert problem.cone.dim == 1 + mean_std.L.shape[0]
+    np.testing.assert_array_equal(problem.G[0], [0.0, 0.0, 1.0])
+    np.testing.assert_array_equal(problem.G[1:, :assets], mean_std.L)
+    np.testing.assert_array_equal(problem.h, np.zeros(problem.cone.dim))
+    np.testing.assert_array_equal(problem.A[:, -1], [0.0])
+    np.testing.assert_array_equal(problem.E[:, -1], [0.0])
+
+
+def test_eq_7_round_trips(mean_std):
+    """The issue's "done when": out to the general form, and back unchanged."""
+    recovered = mean_std.to_socp().as_mean_std()
+    assert recovered.lam == mean_std.lam
+    for block in ("mu", "A", "b", "E", "d", "L"):
+        np.testing.assert_array_equal(getattr(recovered, block), getattr(mean_std, block))
+
+
+def test_round_trip_survives_an_instance_without_linear_constraints():
+    """The cone on its own round-trips too, with empty polyhedral blocks."""
+    form = MeanStdForm(
+        mu=np.array([1.0]),
+        lam=0.5,
+        A=np.zeros((0, 1)),
+        b=np.zeros(0),
+        E=np.zeros((0, 1)),
+        d=np.zeros(0),
+        L=np.array([[1.0]]),
+    )
+    recovered = form.to_socp().as_mean_std()
+    np.testing.assert_array_equal(recovered.mu, [1.0])
+    assert recovered.A.shape == (0, 1)
+
+
+@pytest.mark.parametrize(
+    ("spoil", "match"),
+    [
+        (lambda p: p.add_cone(SecondOrderCone(dim=2), _cone_rows(p), np.zeros(2)), "exactly one cone"),
+        (lambda p: p.augment(1), "must select t"),
+        (lambda p: p.add_inequalities(_last_variable_row(p), np.array([1.0])), "linear inequalities"),
+        (lambda p: p.add_equalities(_last_variable_row(p), np.array([1.0])), "linear equalities"),
+    ],
+)
+def test_as_mean_std_rejects_an_instance_of_another_shape(mean_std, spoil, match):
+    """Reading eq. (7) back is only defined on instances that are in its shape."""
+    with pytest.raises(ProblemError, match=match):
+        spoil(mean_std.to_socp()).as_mean_std()
+
+
+def _cone_rows(problem):
+    """Rows of G for one extra Q^2 factor over an existing instance.
+
+    Args:
+        problem: the instance to extend.
+
+    Returns:
+        A ``(2, n)`` matrix whose head row selects the last variable.
+    """
+    rows = np.zeros((2, problem.num_variables))
+    rows[0, -1] = 1.0
+    return rows
+
+
+def _last_variable_row(problem):
+    """A single constraint row that touches only the last variable.
+
+    Args:
+        problem: the instance the row is for.
+
+    Returns:
+        A ``(1, n)`` matrix selecting the last variable.
+    """
+    row = np.zeros((1, problem.num_variables))
+    row[0, -1] = 1.0
+    return row
+
+
+def test_as_mean_std_rejects_a_nonzero_offset(mean_std):
+    """Eq. (7) has h = 0; an instance with an offset is a more general problem."""
+    problem = mean_std.to_socp()
+    shifted = SOCP(
+        c=problem.c,
+        A=problem.A,
+        b=problem.b,
+        E=problem.E,
+        d=problem.d,
+        G=problem.G,
+        h=np.ones(problem.cone.dim),
+        cone=problem.cone,
+    )
+    with pytest.raises(ProblemError, match="h must be zero"):
+        shifted.as_mean_std()
+
+
+@pytest.mark.parametrize(
+    ("block", "value", "match"),
+    [
+        ("mu", np.zeros(0), "at least one asset"),
+        ("lam", 0.0, "lam > 0"),
+        ("lam", -1.0, "lam > 0"),
+        ("lam", float("nan"), "lam > 0"),
+        ("L", np.zeros((1, 3)), "expected 2 columns"),
+        ("L", np.zeros((0, 2)), "at least one row"),
+        ("A", np.zeros((1, 3)), "expected 2 columns"),
+    ],
+)
+def test_mean_std_validation(mean_std, block, value, match):
+    """Eq. (7)'s own blocks are validated against the number of assets."""
+    blocks = {name: getattr(mean_std, name) for name in ("mu", "lam", "A", "b", "E", "d", "L")}
+    blocks[block] = value
+    with pytest.raises(ProblemError, match=match):
+        MeanStdForm(**blocks)
+
+
+# ----------------------------------------------------------------------------------
+# The one sign convention
+# ----------------------------------------------------------------------------------
+
+
+def test_sign_convention_is_the_one_fixed_convention():
+    """The signs are pinned here.
+
+    A consumer that assembles stationarity itself -- the KKT matrix, the multiplier
+    computation -- reads these three numbers rather than writing signs out. Changing
+    one is a change to the derivation and to every consumer, so it fails here first.
+    """
+    assert SignConvention(inequality=1.0, equality=1.0, cone=-1.0) == SIGN_CONVENTION
+
+
+def test_stationarity_residual_uses_the_convention(mean_std):
+    """The residual is exactly c + A.T @ y + E.T @ nu - G.T @ w, and nothing else."""
+    problem = mean_std.to_socp()
+    rng = np.random.default_rng(9)
+    y = rng.uniform(size=problem.num_inequalities)
+    nu = rng.normal(size=problem.num_equalities)
+    w = rng.normal(size=problem.cone.dim)
+    expected = (
+        problem.c
+        + SIGN_CONVENTION.inequality * (problem.A.T @ y)
+        + SIGN_CONVENTION.equality * (problem.E.T @ nu)
+        + SIGN_CONVENTION.cone * (problem.G.T @ w)
+    )
+    np.testing.assert_allclose(problem.stationarity_residual(y, nu, w), expected)
+
+
+@pytest.mark.parametrize(("block", "value"), [("y", np.zeros(2)), ("nu", np.zeros(2)), ("w", np.zeros(2))])
+def test_stationarity_residual_checks_the_multiplier_shapes(mean_std, block, value):
+    """A multiplier vector of the wrong length is caught, not broadcast."""
+    problem = mean_std.to_socp()
+    multipliers = {"y": np.zeros(1), "nu": np.zeros(1), "w": np.zeros(problem.cone.dim)}
+    multipliers[block] = value
+    with pytest.raises(ProblemError, match=f"^{block}: expected"):
+        problem.stationarity_residual(**multipliers)
+
+
+# Two instances solved by hand, so that every number below is a fact about the
+# convention rather than a recording of what the code happened to produce.
+#
+# BOUND: one asset, mu = 1, lam = 1/2, x <= 1. The objective is -x + t/2 with
+# t = |x|, so it decreases along x and the bound binds: x = t = 1. Stationarity gives
+# w_t = lam = 1/2 and y = 1 + w_x; cone complementarity w.T @ (t, x) = 0 then forces
+# w_x = -1/2 and so y = 1/2.
+#
+# BUDGET: two assets, mu = (2, 1), lam = 1, sum(x) = 1, Sigma = I. The risk term is
+# isotropic, so the optimum puts everything in the better asset: x = (1, 0), t = 1.
+# Stationarity gives w_t = lam = 1, w_1 = nu - 2, w_2 = nu - 1, and cone
+# complementarity forces nu = 1, hence w = (1, -1, 0), on the boundary of Q.
+GOLDEN = {
+    "bound": {
+        "form": MeanStdForm(
+            mu=np.array([1.0]),
+            lam=0.5,
+            A=np.array([[1.0]]),
+            b=np.array([1.0]),
+            E=np.zeros((0, 1)),
+            d=np.zeros(0),
+            L=np.array([[1.0]]),
+        ),
+        "z": np.array([1.0, 1.0]),
+        "y": np.array([0.5]),
+        "nu": np.zeros(0),
+        "w": np.array([0.5, -0.5]),
+    },
+    "budget": {
+        "form": MeanStdForm(
+            mu=np.array([2.0, 1.0]),
+            lam=1.0,
+            A=np.zeros((0, 2)),
+            b=np.zeros(0),
+            E=np.array([[1.0, 1.0]]),
+            d=np.array([1.0]),
+            L=np.eye(2),
+        ),
+        "z": np.array([1.0, 0.0, 1.0]),
+        "y": np.zeros(0),
+        "nu": np.array([1.0]),
+        "w": np.array([1.0, -1.0, 0.0]),
+    },
+}
+
+
+@pytest.fixture(params=sorted(GOLDEN))
+def golden(request):
+    """One hand-solved instance together with its primal point and multipliers."""
+    return GOLDEN[request.param]
+
+
+def test_golden_instance_is_primal_feasible(golden):
+    """The hand-solved point satisfies every block, cone included."""
+    problem = golden["form"].to_socp()
+    z = golden["z"]
+    assert np.all(problem.A @ z <= problem.b + 1e-12)
+    np.testing.assert_allclose(problem.E @ z, problem.d)
+    head, tail = problem.cone.split(problem.cone_slack(z))[0]
+    assert np.linalg.norm(tail) <= head + 1e-12
+
+
+def test_golden_instance_is_stationary(golden):
+    """The residual vanishes at the hand-solved multipliers, in this convention."""
+    problem = golden["form"].to_socp()
+    residual = problem.stationarity_residual(golden["y"], golden["nu"], golden["w"])
+    np.testing.assert_allclose(residual, np.zeros(problem.num_variables), atol=1e-12)
+
+
+def test_golden_multipliers_are_dual_feasible(golden):
+    """Dual feasibility: y >= 0 for A @ z <= b, and w in K, the cone being self-dual."""
+    assert np.all(golden["y"] >= 0.0)
+    head, tail = golden["form"].to_socp().cone.split(golden["w"])[0]
+    assert np.linalg.norm(tail) <= head + 1e-12
+
+
+def test_golden_multipliers_are_complementary(golden):
+    """Both complementarity conditions, in the same convention as stationarity."""
+    problem = golden["form"].to_socp()
+    z = golden["z"]
+    np.testing.assert_allclose(golden["y"] * (problem.A @ z - problem.b), 0.0, atol=1e-12)
+    np.testing.assert_allclose(golden["w"] @ problem.cone_slack(z), 0.0, atol=1e-12)
+
+
+def test_the_cone_multiplier_head_is_lambda(golden):
+    """The convention's signature: t's stationarity reads w_t = lam, not -lam.
+
+    A consumer that fixes the opposite sign produces w_t = -lam, which is outside Q
+    for lam > 0 and so fails dual feasibility as well as this assertion.
+    """
+    head, _ = golden["form"].to_socp().cone.split(golden["w"])[0]
+    assert head == pytest.approx(golden["form"].lam)
+
+
+@pytest.mark.parametrize("flip", ["y", "nu", "w"])
+def test_flipped_signs_are_not_stationary(golden, flip):
+    """Negating any block of the multipliers breaks stationarity.
+
+    This is what makes the convention checkable rather than merely written down: the
+    opposite convention does not also satisfy it, so a consumer that adopts one
+    silently cannot agree with the residuals.
+    """
+    problem = golden["form"].to_socp()
+    multipliers = {name: golden[name].copy() for name in ("y", "nu", "w")}
+    if multipliers[flip].size == 0:
+        pytest.skip(f"this instance has no {flip} block to flip")
+    multipliers[flip] = -multipliers[flip]
+    residual = problem.stationarity_residual(**multipliers)
+    assert np.linalg.norm(residual) > 1e-9


### PR DESCRIPTION
Closes #9 — the problem representation the four issues after it consume.

## The form

`cosa.problem.socp` represents eq. (7) in the shape the plan's *General SOCPs* section
targets:

```text
min  c.T @ z
s.t. A @ z <= b,  E @ z = d,  G @ z + h in K
```

Eq. (7) is the instance with `z = (x, t)`, `c = (-mu, lam)`, `G = [[0, 1], [L, 0]]`,
`h = 0`. Going general here is not gold-plating: it is what lets the three decisions the
issue asks for be settled once rather than four times.

## The cone is a Cartesian product

`ConeProduct` is a tuple of `SecondOrderCone` factors, with the slices, per-factor blocks
and `(head, tail)` splits the conic working-set logic will iterate over — even though the
solver starts on a single cone. The empty product is allowed and means the instance is an
LP, which is a useful way to exercise the polyhedral half of the algorithm on its own.

The cone is written **head first** (`Q^n = {(s_0, s_1) : ||s_1|| <= s_0}`, head at index
0). That ordering is part of the fixed representation — it is the layout of the slack, of
the dual variable, and of everything either is split into — and `split` is the only place
that indexes it.

## The sign convention, fixed and consumable

The plan defers this one explicitly, so:

```text
Lagr = c.T @ z + y.T @ (A @ z - b) + nu.T @ (E @ z - d) - w.T @ (G @ z + h)
stationarity:  c + A.T @ y + E.T @ nu - G.T @ w = 0,   y >= 0,  w in K
```

The conic term is **subtracted**. That is the choice that keeps `w` in `K` rather than in
`-K` — the condition the plan itself asserts (`w_soc in Q`) — and it gives eq. (7) the
identity `w_0 = lam`: the head of the cone multiplier *is* the risk-aversion parameter.

Two consumption points and no third: `SOCP.stationarity_residual` for the residual, and
`cosa.SIGN_CONVENTION` for the three signs when a consumer assembles the terms into
something else (a KKT matrix, a multiplier solve). Nothing downstream writes the signs
out again.

**One deviation from the plan, deliberate.** The plan's stationarity display prints
`+ L.T @ w` while also asking for `w_soc in Q`. Those cannot both hold for the same `w`:
the sign that leaves `w` in the cone is the minus sign. The plan is explicit that the
display is provisional and the convention is the implementation's to fix, so the sign on
that term flips and nothing else in the plan changes. Recorded, with the reasoning, in
`docs/development/sign-convention.md`.

## How the convention is enforced, not just documented

`tests/test_socp.py` carries **two instances solved by hand** — a bound-constrained
single-asset one and a two-asset budget-constrained one with a nonzero `nu`. Their
multipliers are facts about this convention, not recordings of what the code produced.
Three tests make them a gate:

- `test_sign_convention_is_the_one_fixed_convention` pins the three signs, so a consumer
  that assembles its own terms cannot quietly assemble different ones.
- `test_the_cone_multiplier_head_is_lambda` pins `w_0 = lam` (the opposite choice yields
  `w_0 = -lam`, which is not even in `Q`).
- `test_flipped_signs_are_not_stationary` negates each multiplier block in turn and
  requires stationarity to break — the opposite convention does not also satisfy this
  one, which is what makes the choice checkable.

When #13, #22, #23 and #30 land, they assert against these same instances.

## Room for auxiliary variables

`augment`, `add_inequalities`, `add_equalities` and `add_cone` grow an instance, each
returning a new validated one. The plan's turnover recipe — auxiliary variables plus
linear inequalities — is tested end to end, so the representation admits it without being
reopened.

## Validation

On construction: shape agreement across every block, the cone dimension against `G`'s
rows, finiteness, and an empty objective. Blocks are copied into contiguous `float64`, so
an instance owns its data and no consumer defends against an integer dtype.
`trivially_infeasible()` reports the emptiness visible without solving — a row that
constrains no variable with an inconsistent right-hand side — and leaves everything else,
**conic** emptiness included, to Phase I and to the cone predicates of #16. Deciding
infeasibility is not the representation's job.

## The round trip

`MeanStdForm` is eq. (7)'s own data. `to_socp()` puts `t` last with the risk cone as the
single factor; `SOCP.as_mean_std()` reads `mu`, `lam` and `L` back and refuses instances
of any other shape. That is the issue's *done when*. The portfolio builder of #10 produces
this form — the Cholesky factor of `Sigma` and the portfolio constraints are its business,
not this module's.

## Scope kept off other issues

`stationarity_residual` is the stationarity block alone: the residual set, the tolerances
and the termination criterion stay with #22. Membership, boundary and apex predicates stay
with #16 — which is also why `trivially_infeasible` says nothing about the cone.

## Verification

`make all` — every gate CI runs, all green:

```text
ok  fmt        ok  install     ok  docs-coverage   ok  license     ok  rhiza-test
ok  setup      ok  deps        ok  security        ok  typecheck   ok  test
```

- **82 tests pass** (2 skipped: the flip test skips the block an instance does not have),
  coverage **100%** (gate is 90%)
- `interrogate` docstring coverage **100%** (gate is 100%)
- `ty check src` — all checks passed
- `make complexity` — no block above the ceiling; `make semgrep` — 0 findings
- `make docs-examples` — the sign-convention page's example is **executable and checked**,
  so the documented convention cannot drift from the code
- `make book` + `make book-nav` — all 5 nav targets resolve

## Also

`docs/development/architecture.md` gained the pointer to the new page and lost two
statements that this PR made stale ("every package is empty apart from a docstring",
"exports exactly two names").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
