### PR TITLE
feat: derive the working set from the conic KKT conditions (#23)

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -212,6 +212,38 @@ stays where it is: its instance families, its random specifications and its
 reference-solver oracle are how the library is exercised, not part of what it offers, and
 a `cosa.PortfolioInstance` would suggest otherwise.
 
+## `H` is not `rho*I`
+
+§4.2 writes the direction subproblem's matrix as `H = rho*I`, and Waves 4–6 used exactly
+that. [#23](https://github.com/tschm/cosa/issues/23) replaces it with the Hessian of the
+Lagrangian, `rho*I + sum_j mu_j * grad^2 g_j`, where `g_j` is the `j`-th cone constraint
+and `mu_j` its multiplier. Three consequences are worth stating where they can be found.
+
+**Where the second derivative lives.** In `geometry/tangent.py`, next to the first one,
+rather than in a `geometry/curvature.py` of its own. Both are the local geometry of the
+same object at the same point, both refuse the apex for the same reason, and splitting
+them would mean two modules that must agree about what `u` is. The module is named for
+what it was first used for, not for the whole of what it holds.
+
+**Why this is not "an SQP method with an SOC constraint",** which §3.3 explicitly warns
+against. An SQP method would linearize the conic constraint into a *general* nonlinear
+program and hand the result to a QP solver. What happens here is narrower: the constraint
+stays a cone, the working set stays conic — a factor is `INACTIVE`, `TANGENT` or `APEX`,
+never a row of a linearized system — and the curvature is exact rather than an
+approximation to a Hessian nobody can write down. The Lagrangian Hessian is how a
+*multiplier* enters a *primal* computation, and that coupling is what "primal-dual" names.
+
+**What it costs and what it buys.** It costs one `n × n` symmetric update per iteration,
+formed from a matrix the assembly already has, and nothing in the factorization: the
+`(1, 1)` block was dense before and is dense after. Across the eleven portfolio families
+it roughly halves the iteration count, and on the `ill_conditioned` family it is the
+difference between an answer and the iteration limit. The measurement is
+`tests/test_conic_logic.py`.
+
+The multipliers it needs are the previous iteration's, which makes the scheme a fixed
+point rather than an implicit system. The first iteration uses zero, so a #23 solve and a
+Wave 6 solve begin identically and every difference between them is attributable.
+
 ## The other decision recorded once
 
 The sign convention for the conic KKT conditions lives on

--- a/src/cosa/active_set/__init__.py
+++ b/src/cosa/active_set/__init__.py
@@ -6,8 +6,10 @@ equality constraints, and the currently active geometry of the second-order cone
 Modules (each owned by its own issue):
     working_set: The representation itself, and the rendering of it that Success
         Criterion 3 asks for. Landed.
-    multipliers: Multiplier recovery from the KKT system, and the sign tests that
-        identify removal candidates. Landed.
-    updates: Constraint addition and deletion, and the SOC status transitions.
-        Landed, less the SOC *deactivation* rule, which §7.4 makes a research question.
+    multipliers: Multiplier recovery from the KKT system, the sign tests that identify
+        removal candidates, and the Lagrangian curvature that sends the multipliers back
+        into the primal direction computation. Landed.
+    updates: Constraint addition and deletion, and the SOC status transitions in both
+        directions -- §7.3's activation on the geometry and §7.4's deactivation on the
+        conic multiplier. Landed.
 """

--- a/src/cosa/active_set/multipliers.py
+++ b/src/cosa/active_set/multipliers.py
@@ -46,6 +46,14 @@ the inequality removal rule is :func:`cosa.active_set.updates.removal_candidate`
 rather than reimplemented: this module's job is to produce a ``y``, not to have a second
 opinion about what a wrong-signed one means.
 
+**The multipliers are also an input, not only an output.** #23 puts them back into the
+*primal* computation: the direction subproblem's matrix is the Hessian of the Lagrangian,
+``rho*I + sum_j mu_j * grad^2 g_j``, and the ``mu_j`` are these multipliers. That coupling
+is the whole of what "primal-dual" means in §3.3 (``paper.tex:301``) -- not that duals are
+computed alongside primals, which any active-set method does, but that the dual variables
+determine the primal step. :func:`lagrangian_curvature` is that term, and its derivation is
+in its docstring.
+
 **Level 2 is what this module is measured against.** §14.2 (``paper.tex:1028``) asks that
 "the computed multipliers satisfy the stationarity equations to within a prescribed
 tolerance", and :meth:`Multipliers.stationarity_error` is that number.
@@ -60,11 +68,11 @@ import numpy as np
 
 from cosa.active_set.working_set import ConeStatus, WorkingSet
 from cosa.geometry.soc import TOLERANCE, slack
-from cosa.geometry.tangent import tangent_covector
+from cosa.geometry.tangent import curvature, tangent_covector
 from cosa.problem.socp import SIGN_CONVENTION, ProblemError, _vector
 
 if TYPE_CHECKING:
-    from cosa import Vector
+    from cosa import Matrix, Vector
     from cosa.linear_algebra.kkt import Direction
     from cosa.problem.socp import SOCP
 
@@ -74,6 +82,7 @@ __all__ = [
     "dual_cone_violation",
     "from_direction",
     "is_dual_feasible",
+    "lagrangian_curvature",
 ]
 
 STATIONARITY_TOLERANCE: Final = 1e-8
@@ -293,3 +302,82 @@ def is_dual_feasible(
     if multipliers.inequality_violation(tolerance=tolerance) > 0.0:
         return False
     return max(dual_cone_violation(problem, multipliers), default=0.0) <= tolerance
+
+
+def lagrangian_curvature(
+    problem: SOCP,
+    working_set: WorkingSet,
+    z: Vector,
+    multipliers: Multipliers,
+    *,
+    tolerance: float = TOLERANCE,
+) -> Matrix:
+    """The conic constraints' contribution to the Hessian of the Lagrangian.
+
+    **Why there is one at all.** The SOCP's objective is linear, so ``grad^2 f`` is zero and
+    it is tempting to conclude the Lagrangian has no curvature either. It does: the *cone*
+    is curved. Writing the active factor as the scalar constraint
+
+        g(z) = ||s_1|| - s_0 <= 0,      s = G_block @ z + h_block
+
+    the Lagrangian is ``c.T @ z + ... + sum_j mu_j * g_j(z)`` and its Hessian is
+    ``sum_j mu_j * G_j.T @ grad^2 g_j @ G_j``, with ``grad^2 g_j`` the boundary's second
+    derivative that :func:`cosa.geometry.tangent.curvature` supplies. A direction subproblem
+    built on ``rho*I`` alone knows only the tangent *plane* and so takes a step along a
+    straight line that immediately leaves a curved surface; one built on this knows which
+    way the surface bends away and how fast.
+
+    **Where ``mu`` comes from.** Matching ``mu * grad g = -mu * G.T @ covector`` against the
+    convention's ``-G.T @ w`` gives ``w = mu * covector``, and ``covector``'s head is ``1``,
+    so ``mu`` is simply ``w``'s head. No new quantity is introduced and no sign is
+    re-derived: the multiplier this needs is a component of the one
+    :func:`from_direction` already produces.
+
+    **It cannot make the subproblem non-convex**, which is the usual hazard of a Lagrangian
+    Hessian and is not one here. ``grad^2 g`` is positive semidefinite because ``g`` is
+    convex, and ``mu`` is non-negative whenever the multipliers are dual feasible -- so the
+    sum is a positive semidefinite matrix added to ``rho*I``, and the subproblem keeps its
+    unique solution. A *dual infeasible* ``mu`` could break that, which is why a negative
+    head is clipped rather than trusted: a factor whose multiplier has the wrong sign is one
+    :func:`cosa.active_set.updates.deactivate_cones` is about to remove, and it should not
+    be allowed to bend the direction on its way out.
+
+    **Apex factors contribute nothing.** ``g`` is not differentiable at the apex, so there
+    is no ``grad^2 g`` to weight -- the curvature there is infinite in every turning
+    direction, which is the geometric content of #24 needing its own branch. Returning zero
+    for those factors is not an approximation; it is the statement that this term is not the
+    right local description there, and that the apex branch is.
+
+    Args:
+        problem: the instance.
+        working_set: what is currently believed active.
+        z: the current point, whose slack supplies each active factor's ``u``.
+        multipliers: the multipliers to weight the curvature by, ordinarily the previous
+            iterate's -- the direction needs them before it can produce them, and using the
+            last available ones is what makes the scheme a fixed-point iteration rather than
+            an implicit one.
+        tolerance: the vanishing-tail tolerance.
+
+    Returns:
+        The ``(n, n)`` symmetric positive semidefinite matrix to add to ``rho*I``. All zeros
+        when no factor is tangent, when every ``mu`` is zero, or at an apex-only working
+        set -- in which case the subproblem is exactly the one Waves 4-6 solved.
+
+    Raises:
+        ProblemError: if the working set's shape does not match the problem's.
+    """
+    if working_set.num_inequalities != problem.num_inequalities or working_set.cone != problem.cone:
+        raise ProblemError("shape", "the working set and the problem describe different instances")
+    total = np.zeros((problem.num_variables, problem.num_variables))
+    conic = problem.cone_slack(_vector("z", z, size=problem.num_variables))
+    blocks = problem.cone.blocks(_vector("w", multipliers.w, size=problem.cone.dim))
+    for factor, status in enumerate(working_set.cone_status):
+        if status is not ConeStatus.TANGENT:
+            continue
+        weight = max(0.0, float(blocks[factor][0]))
+        if weight == 0.0:
+            continue
+        span = problem.cone.slices[factor]
+        rows = problem.G[span]
+        total += weight * (rows.T @ curvature(conic[span], tolerance=tolerance) @ rows)
+    return total

--- a/src/cosa/active_set/updates.py
+++ b/src/cosa/active_set/updates.py
@@ -17,10 +17,11 @@ them:
   detection and regularization, and it is the only one of the three that alters *what the
   solver believes is active*. :func:`drop_dependent_rows` is it. Losing it among the
   factorization work is the mistake #25 explicitly warns about.
-* **§7.4 SOC deactivation.** Deliberately *not* here. The plan calls it "a key research
-  component" and says the decision must come from the conic multiplier and the normal-cone
-  conditions rather than from the geometry, so it belongs to #23. What this module offers
-  is :func:`set_cone_status`, the primitive that issue will drive.
+* **§7.4 SOC deactivation.** "A key research component" (``paper.tex:609``), answered by
+  #23. The decision is not geometric: a factor stays active for as long as its conic
+  multiplier says the cone contributes a genuine active normal, and is turned off the
+  moment it does not. :func:`deactivate_cones` is that rule, built on
+  :func:`set_cone_status`.
 
 Every function is pure: it takes a working set and returns a new one, or takes a working
 set and returns an index. Nothing is mutated, and no function here solves anything -- the
@@ -50,6 +51,9 @@ from __future__ import annotations
 from dataclasses import replace
 from typing import TYPE_CHECKING, Final
 
+import numpy as np
+
+from cosa.active_set.multipliers import Multipliers, dual_cone_violation
 from cosa.active_set.working_set import ConeStatus, WorkingSet
 from cosa.geometry.soc import ConePosition, positions
 from cosa.problem.socp import SIGN_CONVENTION, ProblemError, _vector
@@ -65,6 +69,7 @@ __all__ = [
     "activation_candidates",
     "add_inequality",
     "cone_status_for",
+    "deactivate_cones",
     "drop_dependent_rows",
     "drop_inequality",
     "inequality_slack",
@@ -223,8 +228,8 @@ def cone_status_for(position: ConePosition) -> ConeStatus:
 
     Returns:
         The status the geometry argues for. §7.3 warns this is not the last word: a cone
-        can be geometrically active and still carry no genuine active normal, which is
-        #23's business.
+        can be geometrically active and still carry no genuine active normal, and
+        :func:`deactivate_cones` is what asks.
     """
     match position:
         case ConePosition.INTERIOR:
@@ -238,9 +243,8 @@ def cone_status_for(position: ConePosition) -> ConeStatus:
 def set_cone_status(working_set: WorkingSet, index: int, status: ConeStatus) -> WorkingSet:
     """Set cone factor ``index``'s status, whatever it currently is.
 
-    The unconditional primitive. Activation has a rule of its own in
-    :func:`activate_cones`; deactivation does not have one yet, on purpose -- §7.4 makes it
-    a research question and #23 answers it -- so this is what that issue will build on.
+    The unconditional primitive that both rules are built from:
+    :func:`activate_cones` for §7.3 and :func:`deactivate_cones` for §7.4.
 
     Args:
         working_set: the set to change.
@@ -281,7 +285,8 @@ def activate_cones(
       only about which face of it is.
     * an active factor whose slack has grown is **left active**. Turning it off is
       deactivation, and §7.4 refuses to decide that on the geometry alone. This function
-      is monotone in activity by design; #23 is what turns a cone off.
+      is monotone in activity by design; :func:`deactivate_cones` is what turns a cone off,
+      and it reads the multiplier rather than the slack.
 
     Args:
         problem: the instance, for its cone product and conic slack.
@@ -322,8 +327,8 @@ def drop_dependent_rows(
     **Only inequalities may be dropped, and that is not a simplification.** §3.1 imposes
     every equality unconditionally, so an equality row is not the solver's to remove even
     when it is the redundant one; and a cone's rows encode a geometric belief that §7.4
-    hands to the conic multiplier, so removing one is #23's decision and not a numerical
-    repair. When the dependency lies entirely among rows that cannot be dropped, this
+    hands to the conic multiplier, so removing one is :func:`deactivate_cones`'s decision
+    and not a numerical repair. When the dependency lies entirely among rows that cannot be dropped, this
     returns the set unchanged and the caller falls back to regularization -- which is
     exactly why §8.3 lists both.
 
@@ -353,3 +358,75 @@ def drop_dependent_rows(
     for index in droppable:
         updated = drop_inequality(updated, index)
     return updated, tuple(droppable)
+
+
+def deactivate_cones(
+    problem: SOCP,
+    working_set: WorkingSet,
+    multipliers: Multipliers,
+    *,
+    tolerance: float = MULTIPLIER_TOLERANCE,
+) -> tuple[WorkingSet, tuple[int, ...]]:
+    """Turn cones off, on the multiplier rather than the geometry -- §7.4.
+
+    §7.4 (``paper.tex:609``) asks for the conic KKT multiplier and the normal-cone
+    conditions to "determine whether the cone contributes a genuine active normal at the
+    candidate solution", and that phrase decomposes into exactly two ways a factor can fail
+    to contribute one:
+
+    * **The normal points the wrong way.** Dual feasibility asks ``w in Q``, and
+      :func:`cosa.active_set.multipliers.dual_cone_violation` measures the failure. A
+      violating factor is not merely uninformative -- it is being held in a direction the
+      problem does not want held, exactly as a wrong-signed ``y`` is in §7.2, and the
+      response is the same: drop it.
+    * **There is no normal.** ``w = 0`` satisfies ``w in Q`` and contributes nothing to
+      stationarity, so the cone is doing no work. Keeping it costs a row in ``W`` that
+      constrains the direction for no reason; releasing it lets the next direction move off
+      the boundary if that is where the objective goes, and re-activation is one geometric
+      test away if it is not.
+
+    **Why this is one rule and not two.** Both are the statement ``w`` is not a nonzero
+    element of ``Q``, which is to say ``w`` is not in the interior of the normal cone. §8.1
+    (``paper.tex:644``) makes the same point in the other direction, and the two shapes the
+    test takes -- a scalar at a tangent factor, a cone membership at an apex factor -- are
+    the module docstring of :mod:`cosa.active_set.multipliers`, not a branch here. This
+    function asks one question and the shape of the answer follows the status.
+
+    **What it is emphatically not.** It is not "the slack grew, so turn the cone off". That
+    rule is what makes an active-set method cycle: an iterate a hair off the boundary
+    deactivates, the unconstrained direction walks straight back, and the factor reactivates
+    forever. The multiplier is the quantity that knows whether the constraint is *wanted*,
+    and this is why §7.4 insists on it.
+
+    **The apex is the case with teeth.** At an apex factor ``w`` is a whole block and the
+    test is a genuine cone membership. #24 established that on eq. (7) a released apex is
+    arithmetically unreachable -- the head row pins ``t`` -- so a factor that fails this
+    test at the apex is a real finding rather than a routine drop, and
+    :func:`cosa.solver.apex.is_apex_optimal` is the other half of the answer.
+
+    Args:
+        problem: the instance, for its cone product.
+        working_set: the current set.
+        multipliers: the multipliers at the current point, ordinarily the ones
+            :func:`cosa.active_set.multipliers.from_direction` just produced.
+        tolerance: how large a dual violation, and how large a multiplier, count as zero.
+            The multiplier tolerance rather than the activation one: this is a judgement
+            about a dual quantity, and it shares its scale with §7.2's.
+
+    Returns:
+        The updated set, and the factors that were turned off, in factor order. An empty
+        tuple means every active factor earned its place.
+    """
+    violations = dual_cone_violation(problem, multipliers)
+    blocks = problem.cone.blocks(_vector("w", multipliers.w, size=problem.cone.dim))
+    updated = working_set
+    dropped: list[int] = []
+    for index, status in enumerate(working_set.cone_status):
+        if not status.is_active:
+            continue
+        infeasible = violations[index] > tolerance
+        absent = float(np.abs(blocks[index]).max(initial=0.0)) <= tolerance
+        if infeasible or absent:
+            updated = set_cone_status(updated, index, ConeStatus.INACTIVE)
+            dropped.append(index)
+    return updated, tuple(dropped)

--- a/src/cosa/geometry/__init__.py
+++ b/src/cosa/geometry/__init__.py
@@ -5,8 +5,10 @@ this subpackage.
 
 Modules (each owned by its own issue):
     soc: Membership, boundary and apex predicates. Landed.
-    tangent: The unit vector ``u = L @ x / ||L @ x||`` and the tangent condition
-        ``tau - u.T @ L @ p = 0`` at a nonzero boundary point. Landed.
+    tangent: The unit vector ``u = L @ x / ||L @ x||``, the tangent condition
+        ``tau - u.T @ L @ p = 0`` at a nonzero boundary point, and the boundary's
+        *curvature* -- the second derivative the tangent plane leaves out, which is what
+        #23's direction subproblem is built on. Landed.
     step: The exact step interval from the scalar quadratic in ``alpha``, and its
         intersection with the linear step bounds. Landed -- with eq. (6) corrected; see
         the module docstring.

--- a/src/cosa/geometry/tangent.py
+++ b/src/cosa/geometry/tangent.py
@@ -38,6 +38,15 @@ computation and #23's deactivation test are both statements about that single nu
 golden instances of ``tests/test_socp.py`` are the arithmetic check: their hand-derived
 ``w`` is this covector scaled by ``lam``.
 
+**Curvature is here too, and it is what "the tangent alone" is missing.** §3.3
+(``paper.tex:301``) says the tangent representation is the *initial* one and the final
+algorithm is to be "formulated in terms of the primal-dual conic KKT conditions". The gap
+between those two is exactly one derivative: the tangent gives the constraint's *gradient*
+at a boundary point, and the boundary is curved, so a method that knows only the gradient
+crawls along it. :func:`curvature` supplies the second derivative, and #23 puts it into the
+direction subproblem weighted by the conic multiplier -- which is what makes that
+computation primal-*dual* rather than primal with a dual afterthought.
+
 **The apex is refused, loudly.** ``u`` does not exist at ``L @ x = 0``, and §8.1
 (``paper.tex:623``) says so: the apex "has a different tangent and normal geometry from a
 smooth nonzero boundary point". Every function here raises :class:`ApexError` rather than
@@ -63,6 +72,7 @@ if TYPE_CHECKING:
 __all__ = [
     "ApexError",
     "NotOnBoundaryError",
+    "curvature",
     "outward_normal",
     "require_boundary",
     "tangent_covector",
@@ -318,3 +328,47 @@ def require_boundary(s: Vector, *, tolerance: float = TOLERANCE, scale: float | 
         raise ApexError()
     if not is_boundary(s, tolerance=tolerance, scale=scale):
         raise NotOnBoundaryError(slack(s))
+
+
+def curvature(s: Vector, *, tolerance: float = TOLERANCE, scale: float | None = None) -> Matrix:
+    """The second derivative of ``g(s) = ||s_1|| - s_0`` at a boundary point.
+
+    The constraint function is linear in the head and a norm in the tail, so all of its
+    curvature lives in the tail block:
+
+        d^2 g / ds^2 = [[0, 0], [0, (I - u u.T) / ||s_1||]]
+
+    which is the projector off ``u``, scaled by the distance from the axis. Two properties
+    make it the right thing to hand a direction subproblem:
+
+    * it is **positive semidefinite**, so adding a non-negative multiple of it to ``rho*I``
+      keeps the subproblem convex and its solution unique. That is not automatic for a
+      Lagrangian Hessian in general -- it is a gift of the constraint being convex.
+    * it is **singular along** ``u``. Moving radially -- straight out along the tail --
+      changes ``||s_1||`` at a constant rate, so there is no curvature in that direction,
+      and the matrix says so. The curvature is entirely in the directions that *turn*.
+
+    It also grows without bound as ``||s_1||`` falls, which is the apex announcing itself
+    from a distance: the boundary's curvature is what becomes infinite there, not merely the
+    tangent's definition that fails. #24's branch is the answer, and this function refuses
+    the point rather than returning an enormous matrix.
+
+    Args:
+        s: the boundary point, head first.
+        tolerance: the vanishing-tail tolerance.
+        scale: the problem scale for that test, or ``None`` to derive it from ``s``.
+
+    Returns:
+        The full ``(s.size, s.size)`` second derivative, in this factor's slack coordinates.
+        The head row and column are zero.
+
+    Raises:
+        ApexError: if ``s``'s tail vanishes, which includes the apex.
+    """
+    unit = unit_tail(s, tolerance=tolerance, scale=scale)
+    _, tail = _split(s)
+    norm = float(np.linalg.norm(tail))
+    block = (np.eye(unit.size) - np.outer(unit, unit)) / norm
+    second = np.zeros((unit.size + 1, unit.size + 1))
+    second[1:, 1:] = block
+    return second

--- a/src/cosa/linear_algebra/kkt.py
+++ b/src/cosa/linear_algebra/kkt.py
@@ -56,7 +56,7 @@ import numpy as np
 from cosa.active_set.working_set import ConeStatus, WorkingSet
 from cosa.geometry.soc import TOLERANCE
 from cosa.geometry.tangent import tangent_row
-from cosa.problem.socp import ProblemError, _vector
+from cosa.problem.socp import ProblemError, _matrix, _vector
 
 if TYPE_CHECKING:
     from cosa import Matrix, Vector
@@ -327,6 +327,7 @@ def assemble(
     rho: float = RHO,
     tolerance: float = TOLERANCE,
     regularization: float = 0.0,
+    curvature: Matrix | None = None,
 ) -> KktSystem:
     """Build the system of §4.3 for the current working set and point.
 
@@ -346,6 +347,15 @@ def assemble(
             dependent working set solvable, at the price of an answer to a nearby question,
             whereas ``rho`` perturbs nothing. Zero leaves the system exactly as §4.3 prints
             it. See #25.
+        curvature: an optional symmetric positive semidefinite ``(n, n)`` matrix added to
+            ``rho*I`` in the ``(1, 1)`` block, making that block the Hessian of the
+            Lagrangian rather than a pure regularizer. §4.2 writes ``H = rho*I`` and Waves
+            4-6 used exactly that; #23 supplies
+            :func:`cosa.active_set.multipliers.lagrangian_curvature` here instead, which is
+            what turns a tangent-plane step into one that accounts for how the cone bends.
+            ``None`` is ``rho*I``, unchanged. Definiteness is not verified here -- the
+            caller that builds the term is the one that can cheaply guarantee it, and
+            :func:`solve` reports a singular system if the guarantee is broken.
 
     Returns:
         The assembled system.
@@ -362,6 +372,8 @@ def assemble(
     rows, variables = matrix_w.shape
     matrix = np.zeros((variables + rows, variables + rows))
     matrix[:variables, :variables] = rho * np.eye(variables)
+    if curvature is not None:
+        matrix[:variables, :variables] += _matrix("curvature", curvature, rows=variables, columns=variables)
     matrix[:variables, variables:] = matrix_w.T
     matrix[variables:, :variables] = matrix_w
     if regularization:
@@ -487,6 +499,7 @@ def direction(
     tolerance: float = TOLERANCE,
     rank_tolerance: float | None = None,
     regularization: float = 0.0,
+    curvature: Matrix | None = None,
 ) -> Direction:
     """Assemble and solve in one call -- what step 5 of the §4.1 iteration does.
 
@@ -499,6 +512,7 @@ def direction(
         rank_tolerance: the singular-value threshold for the dependent-row check.
         regularization: §8.3's ``delta``. A positive value makes a dependent working set
             solvable instead of refused -- see :func:`assemble`.
+        curvature: the Lagrangian's conic curvature term, or ``None`` for ``H = rho*I``.
 
     Returns:
         The direction and its multipliers.
@@ -507,7 +521,15 @@ def direction(
         SingularKktError: if the working-set rows are linearly dependent and no
             regularization was asked for.
     """
-    system = assemble(problem, working_set, z, rho=rho, tolerance=tolerance, regularization=regularization)
+    system = assemble(
+        problem,
+        working_set,
+        z,
+        rho=rho,
+        tolerance=tolerance,
+        regularization=regularization,
+        curvature=curvature,
+    )
     return solve(system, rank_tolerance=rank_tolerance)
 
 

--- a/src/cosa/solver/__init__.py
+++ b/src/cosa/solver/__init__.py
@@ -10,6 +10,8 @@ Modules (each owned by its own issue):
         are #30's.
     termination: The five conic KKT residuals of §6 that constitute the stopping
         criterion. Landed.
-    cosa: The iteration itself -- §9 Phase III's four ingredients wired together.
-        Landed, with activation only; §7.4's deactivation is #23's.
+    cosa: The iteration itself -- §9 Phase III's four ingredients wired together, then
+        §9 Phase IV's conic working-set logic on top: the direction subproblem carries the
+        Lagrangian's conic curvature, and §7.4 decides deactivation on the multiplier.
+        Landed.
 """

--- a/src/cosa/solver/apex.py
+++ b/src/cosa/solver/apex.py
@@ -47,8 +47,10 @@ This module holds instead, and says so in :attr:`ApexDirection.reason`. Holding 
 feasible and often still a descent direction, so nothing is broken; but a dual violation
 that the branch cannot act on is exactly the shape of Risk 1
 ([#39](https://github.com/tschm/cosa/issues/39)) -- "the SOC working-set concept may be
-insufficient". If that reason is ever seen in practice, #39 is the issue it belongs to,
-and #23's primal-dual conic working-set logic is where the fix would live. Recording it is
+insufficient". If that reason is ever seen in practice, #39 is the issue it belongs to.
+#23's :func:`cosa.active_set.updates.deactivate_cones` is the rule that *would* authorize
+the release; what it cannot supply is a feasible direction to release into, which is why
+the case survived it. Recording it is
 more useful than pretending the case does not arise.
 
 **On eq. (7) that case is not an edge case -- it is the only case.** Releasing by dropping

--- a/src/cosa/solver/cosa.py
+++ b/src/cosa/solver/cosa.py
@@ -61,12 +61,30 @@ that inside the cone. Those four things -- a working set of linear constraints, 
 representation, exact conic step lengths, multiplier-based updates -- are §9 Phase III's
 list, and wiring them together is all this module does with them.
 
-**Activation only, which is what breaks the dependency cycle.** §7.3 is explicit that
-geometric activity *"alone is not sufficient to establish optimality"*, and §7.4 hands
-deactivation to the conic multiplier and the normal cone. So a cone that has joined the
-working set never leaves it here. That is #23's, and until it lands an instance whose
-optimum wants the cone *inactive* terminates without a certificate rather than with a wrong
-one -- the residuals say which.
+**Deactivation is the multiplier's decision, and on eq. (7) it provably never fires.**
+§7.3 is explicit that geometric activity *"alone is not sufficient to establish
+optimality"*, and §7.4 hands the other half to the conic multiplier and the normal cone.
+:func:`cosa.active_set.updates.deactivate_cones` is that rule, and the loop consults it
+wherever it consults §7.2's -- at a stationary point, after the inequality test, because a
+drop is only meaningful once the working set has stopped permitting progress.
+
+On the mean-standard-deviation problem it is inert, and the reason is worth writing down.
+``t`` appears in exactly one linear row -- the cone's head -- and in the objective, with
+coefficient ``lam``. Reading the direction subproblem's stationarity in the ``t`` slot gives
+
+    rho * d_t + nu_cone = -lam,      so      w_0 = -nu_cone = lam + rho * d_t,
+
+and at a stationary point ``d = 0``, so ``w_0 = lam``. A tangent factor's ``w`` is
+``-nu_cone * (1, -u)``, whose tail has norm exactly ``|w_0|``, so ``w`` sits precisely on
+the boundary of ``Q`` with a strictly positive head. It can be neither outside ``Q`` nor
+zero. **An active cone at an eq. (7) optimum always contributes a genuine active normal**,
+and §7.4's test says keep it, every time.
+
+That is a result about the formulation, not a limitation of the rule: away from a
+stationary point ``w_0 = lam + rho * d_t`` is free to go negative, and on a general SOCP
+with several factors the test is a real one. It also removes the cycling hazard that a
+geometric deactivation rule would have here -- there is nothing for the rule to release, so
+there is nothing for §7.3 to re-acquire.
 
 **A tangent step is retracted, and the reason is a result rather than an implementation
 choice.** Two facts about eq. (7), both verified in ``tests/test_prototype.py``:
@@ -97,8 +115,19 @@ the objective at first order -- so a short enough step improves the objective, a
 backtracking search finds one. When no step improves it, the point is stationary for the
 working set and the multiplier tests take over.
 
-This is explicitly the *prototype's* answer. §7.4 and #23 replace it with primal-dual conic
-working-set logic, which is where the geometry gets handled rather than stepped around.
+**#23's answer is to give the direction the curvature the tangent plane is missing.** A
+tangent step leaves a curved surface because the subproblem's ``H = rho*I`` describes a
+*plane*; the Lagrangian's Hessian describes the surface. §3.3 asks for a formulation "in
+terms of the primal-dual conic KKT conditions", and
+:func:`cosa.active_set.multipliers.lagrangian_curvature` is what that phrase buys: the dual
+variable ``mu = w_0`` weights the cone's second derivative and enters the *primal* direction
+computation, so the two are solved together rather than one after the other.
+
+The multipliers needed to build it are the ones the last direction produced, which makes the
+scheme a fixed point rather than an implicit system -- the first iteration uses zero and so
+reproduces Waves 4-6 exactly. The retraction stays, because any method that keeps its
+iterates exactly on a curved boundary must restore feasibility after a straight step; what
+changes is how often it has to work hard, and the metrics say by how much.
 
 **The apex is a branch, not a special case in the loop.** When a factor's slack reaches its
 apex the tangent representation has nothing to say, and #24's
@@ -118,7 +147,7 @@ from typing import TYPE_CHECKING, Final
 import numpy as np
 
 from cosa.active_set import updates
-from cosa.active_set.multipliers import Multipliers, from_direction
+from cosa.active_set.multipliers import Multipliers, from_direction, lagrangian_curvature
 from cosa.active_set.working_set import WorkingSet
 from cosa.geometry.soc import is_apex
 from cosa.geometry.step import StepLimit, linear_step, step_limit
@@ -177,10 +206,11 @@ without the anti-cycling rules of #29 the loop can revisit a working set forever
 A thousand rather than the two hundred the polyhedral baseline needed, because the
 retraction changes the cost model. Crawling along a *curved* boundary in tangent steps is a
 first-order process: each step is limited by how far the retraction can be afforded, so the
-count grows as the optimum is approached. The structured families take between thirty and
-three hundred iterations. §9 Phase III (``paper.tex:740``) says correctness matters more
-than speed at this stage, and this is where that is being spent; #27's factorization reuse
-and #23's primal-dual logic are what change it.
+count grows as the optimum is approached. #23's Lagrangian curvature roughly halves that -- measured across the family
+suite, and on the ill-conditioned family it is the difference between an answer and the
+iteration limit -- but the shape of the cost is unchanged, and #27's factorization reuse is
+what addresses the rest. §9 Phase III (``paper.tex:740``) says correctness matters more than
+speed at this stage, and this is where that is being spent.
 """
 
 _STATIONARY: Final = 1e-10
@@ -207,8 +237,9 @@ class Solution:
             ``"stalled"`` or ``"blocked-at-apex"``. A status other than ``"optimal"`` is a
             description of what stopped the loop, not an excuse: each names a specific thing
             that happened. ``"blocked-at-apex"`` is the Risk 1 case #24 identified -- the
-            apex is not justified and cannot be released -- and is the one that belongs to
-            #23 rather than to a bug.
+            apex is not justified and cannot be released, and §7.4's test cannot help
+            because the release it would authorize is arithmetically unavailable. It
+            belongs to #39 rather than to a bug.
         metrics: every quantity §11 and §12.3 ask for.
     """
 
@@ -301,6 +332,11 @@ def solve(
 
     checker.accepted_iterate(problem, point)
     working_set = _working_set_at(problem, point)
+    # The Lagrangian curvature needs multipliers the direction has not produced yet, so the
+    # first pass uses zero -- which is `H = rho*I`, the subproblem Waves 4-6 solved. From
+    # then on each direction is built on the last one's duals: a fixed-point iteration, and
+    # the cheapest honest reading of "primal-dual".
+    previous = _no_multipliers(problem)
 
     with recorder.solving():
         for _ in range(max_iterations):
@@ -338,8 +374,9 @@ def solve(
                 working_set = updates.activate_cones(problem, point, working_set, tolerance=activation)
                 continue
 
+            curvature = lagrangian_curvature(problem, working_set, point, previous)
             try:
-                direction = recorder.solve_direction(problem, working_set, point, rho=rho)
+                direction = recorder.solve_direction(problem, working_set, point, rho=rho, curvature=curvature)
             except SingularKktError:
                 working_set, dropped = updates.drop_dependent_rows(problem, working_set, point)
                 if dropped:
@@ -349,10 +386,16 @@ def solve(
                 if not regularization:
                     return _finish(problem, point, working_set, "degenerate", recorder, stopping)
                 direction = recorder.solve_direction(
-                    problem, working_set, point, rho=rho, regularization=regularization
+                    problem,
+                    working_set,
+                    point,
+                    rho=rho,
+                    regularization=regularization,
+                    curvature=curvature,
                 )
 
             found = from_direction(problem, working_set, point, direction)
+            previous = found
             measured = residuals(problem, point, found)
             recorder.kkt_residual(measured.largest)
 
@@ -360,9 +403,31 @@ def solve(
                 1.0, float(np.abs(point).max(initial=0.0))
             ):
                 checker.computed_multipliers(problem, found)
-                dropping = updates.removal_candidate(working_set, found.y)
-                if dropping is None:
-                    status = "optimal" if measured.is_optimal(tolerance=stopping) else "degenerate"
+                revised = _revise(problem, working_set, found, recorder)
+                if revised is not None:
+                    working_set = revised
+                    continue
+                status = "optimal" if measured.is_optimal(tolerance=stopping) else "degenerate"
+                return Solution(
+                    z=point,
+                    multipliers=found,
+                    working_set=working_set,
+                    residuals=measured,
+                    status=status,
+                    metrics=recorder.metrics(),
+                )
+
+            if working_set.active_cones and _heads_are_free(problem):
+                stepped = _retracted_step(problem, point, direction.d, working_set)
+                if stepped is None:
+                    # No step along this direction improves the objective once the cone has
+                    # been restored, so the point is stationary for this working set even
+                    # though the direction is not zero. The multiplier tests decide next.
+                    revised = _revise(problem, working_set, found, recorder)
+                    if revised is not None:
+                        working_set = revised
+                        continue
+                    status = "optimal" if measured.is_optimal(tolerance=stopping) else "stalled"
                     return Solution(
                         z=point,
                         multipliers=found,
@@ -371,30 +436,6 @@ def solve(
                         status=status,
                         metrics=recorder.metrics(),
                     )
-                working_set = updates.drop_inequality(working_set, dropping)
-                recorder.constraint_removed()
-                continue
-
-            if working_set.active_cones and _heads_are_free(problem):
-                stepped = _retracted_step(problem, point, direction.d, working_set)
-                if stepped is None:
-                    # No step along this direction improves the objective once the cone has
-                    # been restored, so the point is stationary for this working set even
-                    # though the direction is not zero. The multiplier tests decide next.
-                    dropping = updates.removal_candidate(working_set, found.y)
-                    if dropping is None:
-                        status = "optimal" if measured.is_optimal(tolerance=stopping) else "stalled"
-                        return Solution(
-                            z=point,
-                            multipliers=found,
-                            working_set=working_set,
-                            residuals=measured,
-                            status=status,
-                            metrics=recorder.metrics(),
-                        )
-                    working_set = updates.drop_inequality(working_set, dropping)
-                    recorder.constraint_removed()
-                    continue
                 point, limit = stepped
             else:
                 limit = step_limit(problem, point, direction.d, working_set)
@@ -645,3 +686,62 @@ def _finish(
         status=status,
         metrics=recorder.metrics(),
     )
+
+
+def _no_multipliers(problem: SOCP) -> Multipliers:
+    """Zero multipliers, the starting point of the curvature's fixed-point iteration.
+
+    Zero rather than a guess: it makes the first direction subproblem exactly ``H = rho*I``,
+    so the first step of a #23 solve is bit-for-bit the first step of a Wave 6 solve and any
+    difference between them is attributable to the curvature rather than to initialization.
+
+    Args:
+        problem: the instance, for its shape.
+
+    Returns:
+        Multipliers of the right shape, all zero.
+    """
+    return Multipliers(
+        y=np.zeros(problem.num_inequalities),
+        nu=np.zeros(problem.num_equalities),
+        w=np.zeros(problem.cone.dim),
+    )
+
+
+def _revise(
+    problem: SOCP,
+    working_set: WorkingSet,
+    found: Multipliers,
+    recorder: Recorder,
+) -> WorkingSet | None:
+    """The multiplier test of §4.1's step 8: does any multiplier say to drop something?
+
+    Both places the loop stops making progress ask this same question, so it is asked in
+    one place. §7.2's inequality rule is tried first and §7.4's conic rule second, and the
+    order is not arbitrary: a wrong-signed ``y`` is routine and cheap to act on, while
+    releasing a cone changes the local description of the feasible set. Trying the cheaper
+    repair first means the conic test is only ever asked at a point where nothing else
+    explains the halt.
+
+    Args:
+        problem: the instance.
+        working_set: the current set.
+        found: the multipliers at this point.
+        recorder: the metrics recorder, told about each removal and status change.
+
+    Returns:
+        A revised working set to continue from, or ``None`` when every multiplier has the
+        sign its constraint requires -- which is the point at which the residuals get to
+        say whether that means optimal or merely stuck.
+    """
+    dropping = updates.removal_candidate(working_set, found.y)
+    if dropping is not None:
+        recorder.constraint_removed()
+        return updates.drop_inequality(working_set, dropping)
+    updated, dropped = updates.deactivate_cones(problem, working_set, found)
+    if not dropped:
+        return None
+    for index in dropped:
+        recorder.cone_changed(working_set.status(index), updated.status(index))
+        recorder.constraint_removed()
+    return updated

--- a/src/cosa/solver/instrumentation.py
+++ b/src/cosa/solver/instrumentation.py
@@ -57,7 +57,7 @@ from cosa.linear_algebra.kkt import RHO, direction
 from cosa.problem.socp import _vector
 
 if TYPE_CHECKING:
-    from cosa import Vector
+    from cosa import Matrix, Vector
     from cosa.active_set.working_set import ConeStatus, WorkingSet
     from cosa.linear_algebra.kkt import Direction
     from cosa.problem.socp import SOCP
@@ -271,6 +271,7 @@ class Recorder:
         *,
         rho: float = RHO,
         regularization: float = 0.0,
+        curvature: Matrix | None = None,
     ) -> Direction:
         """Solve the direction subproblem, counting one factorization and one solve.
 
@@ -281,13 +282,16 @@ class Recorder:
             rho: the ``rho`` of ``H = rho*I``.
             regularization: §8.3's ``delta``, passed through unchanged. A regularized solve
                 is still one factorization, so it counts the same.
+            curvature: #23's Lagrangian curvature term, passed through unchanged. It changes
+                the ``(1, 1)`` block, not the cost of forming or factorizing it, so it too
+                counts the same.
 
         Returns:
             The direction, exactly as :func:`cosa.linear_algebra.kkt.direction` returns it.
         """
         self._kkt_solves += 1
         with self.factorizing():
-            return direction(problem, working_set, z, rho=rho, regularization=regularization)
+            return direction(problem, working_set, z, rho=rho, regularization=regularization, curvature=curvature)
 
     def iteration(self) -> None:
         """Count one active-set iteration."""

--- a/tests/test_conic_logic.py
+++ b/tests/test_conic_logic.py
@@ -1,0 +1,533 @@
+"""§7.4 and §9 Phase IV: the working set decided by the conic multiplier, not the geometry.
+
+Issue #23. Three things are under test, and they are separable:
+
+* :func:`cosa.geometry.tangent.curvature`, the second derivative of the cone constraint --
+  the object "the tangent alone" is missing;
+* :func:`cosa.active_set.multipliers.lagrangian_curvature`, which weights it by the conic
+  multiplier and so makes the direction subproblem primal-*dual*;
+* :func:`cosa.active_set.updates.deactivate_cones`, §7.4's rule, and the derivation that
+  says it can never fire at an eq. (7) optimum.
+
+The last of those is a claim about the *formulation*, so it is tested twice: once by
+constructing multipliers that violate, to show the rule is real, and once by solving actual
+portfolios and reading the multiplier off the answer, to show that eq. (7) never produces
+such a multiplier.
+"""
+
+import numpy as np
+import pytest
+
+from cosa import SOCP, ConeStatus, Multipliers, ProblemError, SecondOrderCone, WorkingSet
+from cosa.active_set import multipliers as mult
+from cosa.active_set import updates
+from cosa.experiments import portfolio as families
+from cosa.experiments.randomized import random_instance
+from cosa.geometry import soc, tangent
+from cosa.linear_algebra import kkt
+from cosa.solver import cosa as solver
+
+
+@pytest.fixture
+def instance():
+    """A portfolio whose optimum has the cone active, which is the interesting case."""
+    return families.basic(6, seed=3)
+
+
+@pytest.fixture
+def active(instance):
+    """That instance's witness, its working set with the cone tangent, and the problem."""
+    working_set = updates.set_cone_status(WorkingSet.empty(instance.problem), 0, ConeStatus.TANGENT)
+    return instance.problem, instance.witness, working_set
+
+
+# ----------------------------------------------------------------------------------
+# The second derivative
+# ----------------------------------------------------------------------------------
+
+
+def test_the_curvature_is_the_projector_off_the_axis():
+    """`(I - u u.T) / ||s_1||` in the tail block, and zero in the head row and column."""
+    s = np.array([5.0, 3.0, 4.0])
+    second = tangent.curvature(s)
+    assert second.shape == (3, 3)
+    assert not second[0].any()
+    assert not second[:, 0].any()
+    unit = np.array([0.6, 0.8])
+    assert second[1:, 1:] == pytest.approx((np.eye(2) - np.outer(unit, unit)) / 5.0)
+
+
+def test_there_is_no_curvature_along_the_radial_direction():
+    """Moving straight out along the tail changes `||s_1||` at a constant rate.
+
+    So the second derivative is singular in that direction, and says so exactly. This is
+    the same degeneracy that makes the radial ray the one direction an exact conic step can
+    move along -- #18's result, seen from the second derivative rather than the first.
+    """
+    s = np.array([13.0, 5.0, 12.0])
+    radial = np.concatenate([[0.0], s[1:] / np.linalg.norm(s[1:])])
+    assert tangent.curvature(s) @ radial == pytest.approx(np.zeros(3), abs=1e-12)
+
+
+def test_the_curvature_is_positive_semidefinite():
+    """Which is what keeps the direction subproblem convex once it is added to `rho*I`.
+
+    Not a numerical accident: `g(s) = ||s_1|| - s_0` is convex, so its Hessian is positive
+    semidefinite wherever it exists, and this is that fact in arithmetic.
+    """
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        s = rng.normal(size=5)
+        s[0] = float(np.linalg.norm(s[1:]))
+        assert float(np.linalg.eigvalsh(tangent.curvature(s)).min()) >= -1e-12
+
+
+def test_the_curvature_grows_as_the_apex_is_approached():
+    """`1 / ||s_1||` blows up, which is the apex announcing itself from a distance."""
+    near = tangent.curvature(np.array([1e-3, 1e-3, 0.0]))
+    far = tangent.curvature(np.array([1.0, 1.0, 0.0]))
+    assert float(np.abs(near).max()) > 100.0 * float(np.abs(far).max())
+
+
+def test_the_apex_has_no_curvature_because_it_has_no_derivative():
+    """Refused rather than returned as an enormous matrix. #24's branch is the answer."""
+    with pytest.raises(tangent.ApexError):
+        tangent.curvature(np.zeros(3))
+
+
+def test_the_curvature_matches_a_finite_difference():
+    """The definitional check: it is the second derivative of `g`, not merely a formula."""
+    s = np.array([5.0, 3.0, 4.0])
+
+    def g(point):
+        """The cone constraint as a scalar function of the slack."""
+        return float(np.linalg.norm(point[1:]) - point[0])
+
+    step = 1e-5
+    numerical = np.zeros((3, 3))
+    for i in range(3):
+        for j in range(3):
+            shift_i, shift_j = np.zeros(3), np.zeros(3)
+            shift_i[i] = shift_j[j] = step
+            numerical[i, j] = (g(s + shift_i + shift_j) - g(s + shift_i) - g(s + shift_j) + g(s)) / step**2
+    assert tangent.curvature(s) == pytest.approx(numerical, abs=1e-4)
+
+
+# ----------------------------------------------------------------------------------
+# The Lagrangian's curvature: the dual variable entering the primal computation
+# ----------------------------------------------------------------------------------
+
+
+def test_an_inactive_cone_contributes_nothing(instance):
+    """No active factor, no term -- and so the subproblem is exactly Wave 6's."""
+    problem, witness = instance.problem, instance.witness
+    empty = WorkingSet.empty(problem)
+    zero = solver._no_multipliers(problem)
+    assert not mult.lagrangian_curvature(problem, empty, witness, zero).any()
+
+
+def test_a_zero_multiplier_contributes_nothing(active):
+    """`mu = 0` says the constraint is not being pushed against, so it bends nothing."""
+    problem, witness, working_set = active
+    zero = solver._no_multipliers(problem)
+    assert not mult.lagrangian_curvature(problem, working_set, witness, zero).any()
+
+
+def test_the_contribution_is_the_multiplier_times_the_pushed_forward_curvature(active):
+    """`mu * G.T @ grad^2 g @ G`, spelled out here and assembled there."""
+    problem, witness, working_set = active
+    slack = problem.cone_slack(witness)
+    unit = tangent.unit_tail(slack)
+    found = Multipliers(
+        y=np.zeros(problem.num_inequalities),
+        nu=np.zeros(problem.num_equalities),
+        w=2.5 * np.concatenate([[1.0], -unit]),
+    )
+    built = mult.lagrangian_curvature(problem, working_set, witness, found)
+    expected = 2.5 * (problem.G.T @ tangent.curvature(slack) @ problem.G)
+    assert built == pytest.approx(expected)
+
+
+def test_the_multiplier_is_read_off_the_head_of_w(active):
+    """`w = mu * covector` and `covector`'s head is one, so `mu` is `w[0]`.
+
+    Doubling the multiplier doubles the term, which is the linearity the derivation claims.
+    """
+    problem, witness, working_set = active
+    unit = tangent.unit_tail(problem.cone_slack(witness))
+    covector = np.concatenate([[1.0], -unit])
+
+    def built(weight):
+        """The curvature term for a `w` of the given magnitude along the covector."""
+        found = Multipliers(
+            y=np.zeros(problem.num_inequalities),
+            nu=np.zeros(problem.num_equalities),
+            w=weight * covector,
+        )
+        return mult.lagrangian_curvature(problem, working_set, witness, found)
+
+    assert built(2.0) == pytest.approx(2.0 * built(1.0))
+
+
+def test_a_dual_infeasible_multiplier_is_clipped_rather_than_trusted(active):
+    """A negative `mu` would make the subproblem non-convex, so it contributes zero.
+
+    The factor it belongs to is one §7.4 is about to remove; it should not be allowed to
+    bend the direction on its way out.
+    """
+    problem, witness, working_set = active
+    unit = tangent.unit_tail(problem.cone_slack(witness))
+    found = Multipliers(
+        y=np.zeros(problem.num_inequalities),
+        nu=np.zeros(problem.num_equalities),
+        w=-3.0 * np.concatenate([[1.0], -unit]),
+    )
+    assert not mult.lagrangian_curvature(problem, working_set, witness, found).any()
+
+
+def test_an_apex_factor_contributes_nothing(instance):
+    """`g` is not differentiable there, so there is no second derivative to weight."""
+    problem = instance.problem
+    apex = np.zeros(problem.num_variables)
+    working_set = updates.set_cone_status(WorkingSet.empty(problem), 0, ConeStatus.APEX)
+    found = Multipliers(
+        y=np.zeros(problem.num_inequalities),
+        nu=np.zeros(problem.num_equalities),
+        w=np.concatenate([[1.0], np.zeros(problem.cone.dim - 1)]),
+    )
+    assert soc.is_apex(problem.cone_slack(apex))
+    assert not mult.lagrangian_curvature(problem, working_set, apex, found).any()
+
+
+def test_the_curvature_refuses_a_working_set_of_the_wrong_shape(instance):
+    """The same shape guard `from_direction` applies, for the same reason."""
+    problem = instance.problem
+    other = WorkingSet.empty(SOCP.unconstrained(np.ones(2)))
+    with pytest.raises(ProblemError, match="different instances"):
+        mult.lagrangian_curvature(problem, other, instance.witness, solver._no_multipliers(problem))
+
+
+# ----------------------------------------------------------------------------------
+# The subproblem it produces
+# ----------------------------------------------------------------------------------
+
+
+def test_the_kkt_block_becomes_the_lagrangian_hessian(active):
+    """`rho*I + curvature`, in the `(1, 1)` block and nowhere else."""
+    problem, witness, working_set = active
+    plain = kkt.assemble(problem, working_set, witness)
+    bent = kkt.assemble(problem, working_set, witness, curvature=np.eye(problem.num_variables))
+    n = problem.num_variables
+    assert bent.matrix[:n, :n] == pytest.approx(plain.matrix[:n, :n] + np.eye(n))
+    assert bent.matrix[n:, :] == pytest.approx(plain.matrix[n:, :])
+    assert bent.rhs == pytest.approx(plain.rhs)
+
+
+def test_no_curvature_is_the_wave_six_subproblem(active):
+    """`None` must be bit-for-bit `H = rho*I`, or the comparison below means nothing."""
+    problem, witness, working_set = active
+    plain = kkt.assemble(problem, working_set, witness)
+    explicit = kkt.assemble(problem, working_set, witness, curvature=None)
+    assert np.array_equal(plain.matrix, explicit.matrix)
+
+
+def test_a_curvature_of_the_wrong_shape_is_refused(active):
+    """It is added to the variable block, so it must have the variable block's shape."""
+    problem, witness, working_set = active
+    with pytest.raises(ProblemError, match="curvature"):
+        kkt.assemble(problem, working_set, witness, curvature=np.eye(problem.num_variables + 1))
+
+
+def test_the_curvature_reaches_the_direction_through_the_one_call_form(active):
+    """`direction` is `assemble` then `solve`, and it must pass the term along."""
+    problem, witness, working_set = active
+    bent = np.eye(problem.num_variables)
+    assert kkt.direction(problem, working_set, witness, curvature=bent).d != pytest.approx(
+        kkt.direction(problem, working_set, witness).d
+    )
+
+
+# ----------------------------------------------------------------------------------
+# §7.4: deactivation on the multiplier
+# ----------------------------------------------------------------------------------
+
+
+def _multipliers(problem, w):
+    """Multipliers with a given `w` and no linear part."""
+    return Multipliers(y=np.zeros(problem.num_inequalities), nu=np.zeros(problem.num_equalities), w=w)
+
+
+def test_a_factor_whose_multiplier_leaves_the_cone_is_released(active):
+    """`w not in Q`: the normal points a way the problem does not want held."""
+    problem, _, working_set = active
+    outside = np.concatenate([[-1.0], np.zeros(problem.cone.dim - 1)])
+    updated, dropped = updates.deactivate_cones(problem, working_set, _multipliers(problem, outside))
+    assert dropped == (0,)
+    assert updated.status(0) is ConeStatus.INACTIVE
+
+
+def test_a_factor_with_no_multiplier_at_all_is_released(active):
+    """`w = 0` is in `Q` and contributes nothing, so the cone is doing no work.
+
+    Keeping it costs a row in `W` for no reason; releasing it lets the next direction move
+    off the boundary, and §7.3 re-acquires it in one geometric test if it should not have.
+    """
+    problem, _, working_set = active
+    updated, dropped = updates.deactivate_cones(problem, working_set, _multipliers(problem, np.zeros(problem.cone.dim)))
+    assert dropped == (0,)
+    assert updated.status(0) is ConeStatus.INACTIVE
+
+
+def test_a_factor_with_a_genuine_active_normal_is_kept(active):
+    """A nonzero `w` in `Q` is exactly what §7.4 asks for, so nothing happens."""
+    problem, witness, working_set = active
+    unit = tangent.unit_tail(problem.cone_slack(witness))
+    found = _multipliers(problem, np.concatenate([[1.0], -unit]))
+    updated, dropped = updates.deactivate_cones(problem, working_set, found)
+    assert dropped == ()
+    assert updated is working_set
+
+
+def test_an_inactive_factor_is_not_a_candidate(instance):
+    """It is already off; there is nothing to release and no multiplier worth reading."""
+    problem = instance.problem
+    empty = WorkingSet.empty(problem)
+    _, dropped = updates.deactivate_cones(problem, empty, _multipliers(problem, np.zeros(problem.cone.dim)))
+    assert dropped == ()
+
+
+def test_the_apex_test_is_a_cone_membership_not_a_scalar(instance):
+    """§8.1's distinction, in the one place it changes an answer.
+
+    At a tangent factor `w` is pinned to the ray through the covector and the test reduces
+    to a sign. At an apex factor `w` is a free block, so a head that is positive is not
+    enough -- the tail has to fit under it.
+    """
+    problem = instance.problem
+    apex_set = updates.set_cone_status(WorkingSet.empty(problem), 0, ConeStatus.APEX)
+    tail = np.zeros(problem.cone.dim - 1)
+    tail[0] = 5.0
+    inside = _multipliers(problem, np.concatenate([[9.0], tail]))
+    outside = _multipliers(problem, np.concatenate([[1.0], tail]))
+    assert updates.deactivate_cones(problem, apex_set, inside)[1] == ()
+    assert updates.deactivate_cones(problem, apex_set, outside)[1] == (0,)
+
+
+def test_deactivation_is_the_multiplier_and_not_the_slack(instance):
+    """The rule §7.4 insists on, and the reason it insists.
+
+    The iterate here is well inside the cone -- the geometry has no case at all for holding
+    the factor -- and the rule keeps it anyway, because the multiplier says it contributes a
+    genuine active normal. A slack-based rule would deactivate, the unconstrained direction
+    would walk straight back, and §7.3 would reactivate: that cycle is what this avoids.
+    """
+    problem = instance.problem
+    interior = instance.witness.copy()
+    interior[-1] += 10.0
+    working_set = updates.set_cone_status(WorkingSet.empty(problem), 0, ConeStatus.TANGENT)
+    unit = tangent.unit_tail(problem.cone_slack(interior))
+    found = _multipliers(problem, np.concatenate([[1.0], -unit]))
+    assert soc.is_interior(problem.cone_slack(interior))
+    assert updates.deactivate_cones(problem, working_set, found)[1] == ()
+
+
+# ----------------------------------------------------------------------------------
+# The derivation: on eq. (7) the rule provably never fires
+# ----------------------------------------------------------------------------------
+
+
+def test_an_active_cone_at_an_optimum_always_has_a_genuine_active_normal():
+    """The module docstring's derivation, checked against actual solves.
+
+    `t` appears in one linear row and in the objective with coefficient `lam`, so the
+    direction subproblem's stationarity in the `t` slot gives `w_0 = lam + rho * d_t`, which
+    at a stationary point is `lam`. The tangent structure then forces `||w_tail|| = w_0`, so
+    `w` sits on the boundary of `Q` with a strictly positive head: neither outside `Q` nor
+    zero, whatever the instance.
+    """
+    for seed in range(6):
+        instance = families.basic(7, seed=seed)
+        answer = solver.solve(instance.problem)
+        assert answer.status == "optimal"
+        if not answer.working_set.active_cones:
+            continue
+        w = answer.multipliers.w
+        assert float(w[0]) == pytest.approx(instance.portfolio.lam, rel=1e-6)
+        assert float(np.linalg.norm(w[1:])) == pytest.approx(float(w[0]), rel=1e-6)
+        assert updates.deactivate_cones(instance.problem, answer.working_set, answer.multipliers)[1] == ()
+
+
+def test_the_solver_never_releases_a_cone_on_a_portfolio():
+    """The same statement as a property of the loop rather than of its answer.
+
+    Every cone that joins a working set on eq. (7) is still in it at termination -- which is
+    a finding about the formulation, not about the rule: `lam > 0` is what makes the head of
+    `w` positive, and a problem whose objective did not charge for risk would not. Read
+    through §7.4 directly, so that a rule which had fired somewhere along the way and left
+    the factor reactivated would still be caught.
+    """
+    for family in (families.basic, families.box, families.sector, families.turnover):
+        instance = family(6, seed=2)
+        answer = solver.solve(instance.problem)
+        assert answer.status == "optimal"
+        assert answer.working_set.active_cones == (0,)
+        assert updates.deactivate_cones(instance.problem, answer.working_set, answer.multipliers)[1] == ()
+
+
+# ----------------------------------------------------------------------------------
+# What the curvature buys, measured
+# ----------------------------------------------------------------------------------
+
+
+def _iterations(problem, *, bend):
+    """Solve with the Lagrangian curvature on or off, and report the count and the status."""
+    if bend:
+        answer = solver.solve(problem)
+    else:
+        real = solver.lagrangian_curvature
+        solver.lagrangian_curvature = lambda *_args, **_kwargs: None
+        try:
+            answer = solver.solve(problem)
+        finally:
+            solver.lagrangian_curvature = real
+    return answer.metrics.iterations, answer.status
+
+
+def test_the_curvature_halves_the_iteration_count():
+    """§9 Phase IV's point, as a number rather than an argument.
+
+    Across the family suite the Lagrangian Hessian roughly halves the work. A first-order
+    method on a curved surface converges linearly and this one does not have to.
+    """
+    total = {True: 0, False: 0}
+    for family in (families.basic, families.sector, families.factor_exposure):
+        for seed in range(4):
+            problem = family(8, seed=seed).problem
+            for bend in (True, False):
+                total[bend] += _iterations(problem, bend=bend)[0]
+    assert total[True] < 0.75 * total[False], total
+
+
+def test_the_curvature_solves_instances_that_rho_i_cannot():
+    """Not merely faster: the difference between an answer and an iteration limit.
+
+    `ill_conditioned` is the family built for #33's robustness question, and under
+    `H = rho*I` the tangent-plane step is short enough that the loop runs out of iterations
+    with a residual around `1e-2`. With the cone's curvature in the subproblem it converges.
+    """
+    problem = families.ill_conditioned(8, seed=0).problem
+    assert _iterations(problem, bend=False)[1] == "iteration_limit"
+    bent = solver.solve(problem)
+    assert bent.status == "optimal"
+    assert bent.residuals.is_optimal()
+
+
+def test_the_first_direction_is_unchanged_by_the_curvature(active):
+    """The fixed point starts at zero, so iteration one is bit-for-bit Wave 6's.
+
+    Which is what makes the comparison above attributable: any difference between the two
+    solves comes from the curvature, not from a different starting subproblem.
+    """
+    problem, witness, working_set = active
+    zero = solver._no_multipliers(problem)
+    built = mult.lagrangian_curvature(problem, working_set, witness, zero)
+    assert np.array_equal(
+        kkt.direction(problem, working_set, witness, curvature=built).d,
+        kkt.direction(problem, working_set, witness).d,
+    )
+
+
+# ----------------------------------------------------------------------------------
+# §7.4 inside the loop, on a problem that is not eq. (7)
+# ----------------------------------------------------------------------------------
+
+
+_ON_THE_BOUNDARY = np.array([1.0, 1.0, 0.0])
+"""The start :func:`_cone_wants_releasing` is entered at: feasible, and on the cone."""
+
+
+def _cone_wants_releasing() -> SOCP:
+    """A three-variable SOCP whose first working set holds a cone it should not.
+
+    ``z = (t, y1, y2)``, the cone is ``||y|| <= t`` on the variables themselves, the
+    equalities pin ``y = (1, 0)``, and the objective *rewards* a large ``t`` up to a bound.
+    The optimum is therefore strictly inside the cone at ``t = 5``, but the constructed
+    start is on the boundary at ``t = 1`` -- supplied rather than constructed, because
+    ``t`` carries an upper bound and so is not one of the free heads
+    :func:`cosa.solver.initialization.raise_free_heads` may raise --
+    so §7.3 activates the factor at the start and the tangent row then pins the direction to
+    zero. Nothing geometric can undo that: the iterate is exactly on the boundary and the
+    working set is exactly stationary. Only the multiplier knows the cone is being held
+    backwards, and it says so loudly, with ``w = (-1, 1, 0)``.
+
+    It is deliberately *not* a portfolio: eq. (7) charges ``lam`` for ``t`` and so can never
+    produce this, which is the whole content of the derivation above.
+    """
+    return (
+        SOCP.unconstrained(np.array([-1.0, 0.0, 0.0]))
+        .add_inequalities([[1.0, 0.0, 0.0]], [5.0])
+        .add_equalities([[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], [1.0, 0.0])
+        .add_cone(SecondOrderCone(3), np.eye(3), np.zeros(3))
+    )
+
+
+def test_a_wrongly_held_cone_is_released_and_the_solve_completes():
+    """§7.4 driving the loop: the release is what makes the instance solvable at all."""
+    problem = _cone_wants_releasing()
+    answer = solver.solve(problem, start=_ON_THE_BOUNDARY)
+    assert answer.status == "optimal"
+    assert answer.z == pytest.approx(np.array([5.0, 1.0, 0.0]))
+    assert answer.working_set.status(0) is ConeStatus.INACTIVE
+    assert answer.residuals.is_optimal()
+
+
+def test_the_released_factor_is_the_one_whose_multiplier_left_the_cone():
+    """Read the offending multiplier directly, so the mechanism is pinned and not inferred."""
+    problem = _cone_wants_releasing()
+    start = _ON_THE_BOUNDARY
+    working_set = updates.set_cone_status(WorkingSet.empty(problem), 0, ConeStatus.TANGENT)
+    found = mult.from_direction(problem, working_set, start, kkt.direction(problem, working_set, start))
+    assert found.w == pytest.approx(np.array([-1.0, 1.0, 0.0]))
+    assert mult.dual_cone_violation(problem, found)[0] == pytest.approx(2.0)
+    assert updates.deactivate_cones(problem, working_set, found)[1] == (0,)
+
+
+def test_without_the_rule_that_instance_never_moves():
+    """The counterfactual, which is what makes the release load-bearing rather than tidy.
+
+    With §7.4 switched off the loop reaches a stationary point of a working set it has no
+    way to leave -- the direction is zero, no inequality is active to drop, and the cone is
+    held -- so it reports the point as optimal when it is nothing of the kind. The residuals
+    are the ones that catch it, which is Success Criterion 2 doing its job.
+    """
+    problem = _cone_wants_releasing()
+    real = updates.deactivate_cones
+    updates.deactivate_cones = lambda _p, w, _m, **_k: (w, ())
+    try:
+        answer = solver.solve(problem, start=_ON_THE_BOUNDARY)
+    finally:
+        updates.deactivate_cones = real
+    assert answer.z == pytest.approx(np.array([1.0, 1.0, 0.0]))
+    assert not answer.residuals.is_optimal()
+
+
+def test_the_curvature_is_what_makes_the_randomized_sweep_converge():
+    """§16.3's generator, which is the hardest thing the solver is pointed at.
+
+    ``experiments/randomized.py`` randomizes the *shape* -- dimension, rank, conditioning,
+    active-set structure -- so a sweep over it is not a family with a favourable geometry.
+    Over the first two hundred seeds the curvature takes the iteration count from 62631 to
+    19386 and the number of instances that reach an optimum from 162 to 192. Thirty seeds
+    are checked here, which is enough to see the gap without making the suite slow, and the
+    assertions are loose because the point is the direction and not the width.
+    """
+    solved = {True: 0, False: 0}
+    total = {True: 0, False: 0}
+    for seed in range(30):
+        problem = random_instance(seed).problem
+        for bend in (True, False):
+            iterations, status = _iterations(problem, bend=bend)
+            total[bend] += iterations
+            solved[bend] += status == "optimal"
+    assert solved[True] > solved[False], solved
+    assert total[True] < 0.5 * total[False], total

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -57,8 +57,11 @@ PUBLIC_SURFACE = [
 # a name like `slack` or `position` only means something next to its module.
 NOT_AT_THE_ROOT = [
     "covariance_factor",
+    "curvature",
+    "deactivate_cones",
     "equilibrate",
     "is_boundary",
+    "lagrangian_curvature",
     "position",
     "positions",
     "removal_candidate",


### PR DESCRIPTION
Closes #23. Wave 7.

§9 Phase IV asks for "a method whose stopping criterion and working-set logic are derived directly from the SOCP KKT conditions", and §3.3 warns against becoming "an SQP method with an SOC constraint". This is both halves.

## §7.4's deactivation rule

`updates.deactivate_cones` releases a factor exactly when its conic multiplier says the cone contributes no genuine active normal — `w` outside `Q`, or `w` zero. §7.4's phrase decomposes into those two and nothing else. It is one test with two shapes: a scalar at a tangent factor, a genuine cone membership at an apex factor, which is the distinction §8.1 is pointing at. It is emphatically **not** "the slack grew, so turn the cone off" — that rule is what makes an active-set method cycle, and the multiplier is the quantity that knows whether a constraint is *wanted*.

The loop consults it wherever it consults §7.2's, through a single `_revise` helper that replaces two copies of the multiplier test.

## On eq. (7) the rule provably never fires, and that is the finding

`t` appears in exactly one linear row — the cone's head — and in the objective with coefficient `lam`. Reading the direction subproblem's stationarity in the `t` slot gives

    rho * d_t + nu_cone = -lam,   so   w_0 = -nu_cone = lam + rho * d_t,

and at a stationary point `d = 0`, so `w_0 = lam`. A tangent factor's `w` is `-nu_cone * (1, -u)`, whose tail has norm exactly `|w_0|`. So `w` sits precisely on the boundary of `Q` with a strictly positive head: neither outside `Q` nor zero.

**An active cone at a mean–standard-deviation optimum always contributes a genuine active normal.** §7.4's test says keep it, every time. That is a result about the formulation rather than a limitation of the rule — away from a stationary point `w_0` is free to go negative — and it removes the cycling hazard a geometric rule would have had here. The rule is exercised in the loop on a constructed three-variable SOCP that eq. (7) cannot produce.

## `H` is no longer `rho*I`

The gap between the tangent representation and a primal-dual conic formulation is one derivative: the tangent knows the boundary's *plane*, and the boundary is curved, so a method that knows only the gradient crawls along it.

- `geometry.tangent.curvature` supplies `grad^2 g = [[0,0],[0,(I - u u^T)/||s_1||]]` — positive semidefinite because `g` is convex, singular along the radial ray because moving straight out changes `||s_1||` at a constant rate, and unbounded at the apex, which is #24's branch announcing itself.
- `multipliers.lagrangian_curvature` weights it by `mu = w_0` and pushes it through `G`, giving the Hessian of the Lagrangian.
- `kkt.assemble` accepts it in the `(1, 1)` block.

That coupling is what "primal-dual" names in §3.3: not that duals are computed alongside primals, which any active-set method does, but that **the dual variable determines the primal step**. It cannot make the subproblem non-convex — `g` is convex and `mu >= 0` — and a dual-infeasible `mu`, belonging to a factor §7.4 is about to remove, is clipped rather than allowed to bend the direction on its way out.

## Measured, not argued

| | `H = rho*I` (Wave 6) | with the curvature |
| --- | --- | --- |
| eleven portfolio families, 66 solves | 9738 iterations, 4 hit the limit | **4691 iterations, 0 hit the limit** |
| 200 randomized instances | 62631 iterations, 162 optimal | **19386 iterations, 192 optimal** |

The multipliers used are the previous iteration's, which makes the scheme a fixed point rather than an implicit system. The first iteration uses zero, so a #23 solve and a Wave 6 solve begin bit-for-bit identically and every difference between them is attributable to the curvature.

The retraction stays. Any method that keeps its iterates exactly on a curved boundary must restore feasibility after a straight step; what changed is how often it has to work hard.

## Done when

- [x] stopping criterion and working-set logic derive from the conic KKT conditions rather than the tangent alone — the five residuals were already §6's; the working set's *changes* now are too, on both sides
- [x] the SOC is removed only when the multiplier / normal-cone condition says it contributes no active normal
- [x] Level 3 optimality holds at termination
- [x] the tangent representation kept only where it is the correct local description — first order at a nonzero boundary point, with the curvature beside it and #24's branch at the apex

All rhiza gates green, 100% coverage, 1026 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved conic solver directions using Lagrangian curvature for better handling of complex and ill-conditioned problems.
  - Added automatic deactivation of cone constraints when multiplier conditions indicate they are no longer active.
  - Added curvature-aware direction solving and instrumentation support.

- **Documentation**
  - Expanded architecture and solver documentation to describe curvature-based directions and cone deactivation.

- **Tests**
  - Added comprehensive coverage for curvature calculations, multiplier effects, deactivation behavior, KKT integration, and convergence improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->