### PR TITLE
feat: the frontier experiment and the four-mode comparison (#35, #34)

### DIFF
--- a/src/cosa/experiments/__init__.py
+++ b/src/cosa/experiments/__init__.py
@@ -9,7 +9,8 @@ Modules (each owned by its own issue):
     failures: §12.4's failure-mode and degeneracy study -- every family classified, every
         switchable mitigation ablated. Landed; its narrative is
         ``docs/development/failure-modes.md``.
-    frontier: The efficient-frontier sequence over lambda, which is where warm
-        starting either pays off or does not.
-    benchmarks: Comparison against reference SOCP solvers.
+    frontier: §11's efficient-frontier sequence over lambda, solved cold and warm, which
+        is where warm starting either pays off or does not. Landed.
+    benchmarks: §12's comparison against reference SOCP solvers, in four modes with both
+        metric tables. Landed.
 """

--- a/src/cosa/experiments/benchmarks.py
+++ b/src/cosa/experiments/benchmarks.py
@@ -1,0 +1,437 @@
+"""COSA against a reference solver, in the four modes §12 asks for.
+
+§12 (``paper.tex:889``) sets out the comparison study, and #34 is it. Four modes, reported
+separately because they are four different questions:
+
+* **cold start** -- one problem, no prior information. The base case, and the one an
+  interior-point method is designed for.
+* **warm start** -- the same problem entered from a neighbour's answer. Where an active-set
+  method is supposed to win, and #30 is what makes it possible.
+* **individual large problems** -- one problem, many assets. Where an active-set method is
+  supposed to lose, because the working set grows with the problem and each iteration costs
+  more.
+* **sequences of related problems** -- #35's frontier, taken as a whole. The mode the
+  project's hypothesis is actually about: not "is COSA faster on one problem" but "is COSA
+  faster on twenty problems that resemble each other".
+
+**Two metric tables, because §12.2 and §12.3 ask two different things.** Accuracy is
+per-solution -- the five residuals, the objective, the expected return, the standard
+deviation -- and is what Success Criterion 5 is checked against. Performance is per-solve --
+wall clock, iterations, KKT solves, active-set changes, factorization time, and memory where
+it is worth the cost of measuring. Reporting them together would let a fast wrong answer
+look good.
+
+**The reference solver is the arbiter, not a competitor.** §16.3 requires every generated
+problem's objective to agree with a reference within tolerance, and that check runs in every
+mode. Timing against CVXPY is reported but is *not* the claim: CVXPY's overhead is its
+modelling layer, not its solver, and a comparison that took it for the solver's cost would
+be measuring the wrong thing. :attr:`Comparison.speedup` exists and its docstring says what
+it is worth.
+
+**Memory is opt-in.** §12.3 asks for it "where relevant" and ``tracemalloc`` roughly doubles
+a solve's cost, so :func:`benchmark` takes a flag and the large-problem mode is the only one
+that sets it by default -- which is the only mode where the answer could be interesting.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Final
+
+from cosa.experiments import portfolio as families
+from cosa.experiments.frontier import sweep
+from cosa.experiments.reference import (
+    ReferenceSolver,
+    SolverUnavailableError,
+    default_solver,
+    relative_gap,
+)
+from cosa.solver import cosa as solver
+from cosa.solver.instrumentation import Metrics, Recorder
+from cosa.solver.warm import WarmStart, from_solution
+
+if TYPE_CHECKING:
+    from cosa.experiments.portfolio import PortfolioInstance
+    from cosa.problem.socp import SOCP
+    from cosa.solver.cosa import Solution
+    from cosa.solver.termination import Residuals
+
+__all__ = [
+    "MODES",
+    "OBJECTIVE_AGREEMENT",
+    "Accuracy",
+    "Comparison",
+    "Performance",
+    "benchmark",
+    "disagreements",
+    "report",
+]
+
+MODES: Final = ("cold", "warm", "large", "sequence")
+"""§12's four modes, in the order the paper lists them (``paper.tex:902``)."""
+
+OBJECTIVE_AGREEMENT: Final = 1e-6
+"""Success Criterion 5's "prescribed tolerance" for agreement with the reference.
+
+Relative. Matched to §6's termination tolerance rather than set tighter: COSA stops when its
+residuals are inside ``1e-6``, so requiring the *objective* to agree more closely than that
+would be requiring an accuracy the stopping criterion does not promise. Where the open
+reference backends disagree with each other by more than this -- which #21 measured at up to
+``1e-5`` on nearly degenerate instances -- the comparison is against the backend's own
+accuracy, not against this.
+"""
+
+
+@dataclass(frozen=True, eq=False)
+class Accuracy:
+    """§12.2's per-solution metrics (``paper.tex:911``).
+
+    Attributes:
+        residuals: §6's five, which are the conic KKT conditions measured.
+        objective: ``c.T @ z`` at COSA's answer.
+        reference: the reference solver's objective, or ``None`` when none was available.
+        gap: the relative difference between them, or ``inf`` when there is no reference.
+        expected_return: ``mu.T @ x``, which is what a portfolio report quotes.
+        deviation: ``sigma(x)``, the other half of the same report.
+    """
+
+    residuals: Residuals
+    objective: float
+    reference: float | None
+    gap: float
+    expected_return: float
+    deviation: float
+
+    @property
+    def agrees(self) -> bool:
+        """Success Criterion 5: does the objective match the reference within tolerance?
+
+        ``True`` when no reference was available, which is not the same as agreement and is
+        why :attr:`reference` is kept: a report that cannot distinguish "agreed" from
+        "nothing to agree with" is not reporting a check.
+        """
+        return self.reference is None or self.gap <= OBJECTIVE_AGREEMENT
+
+    def __str__(self) -> str:
+        """One accuracy row."""
+        against = "no reference" if self.reference is None else f"gap {self.gap:.1e}"
+        return (
+            f"obj {self.objective:12.6f}  {against:16s} "
+            f"residual {self.residuals.largest:8.1e}  "
+            f"return {self.expected_return:8.4f}  sd {self.deviation:7.4f}"
+        )
+
+
+@dataclass(frozen=True, eq=False)
+class Performance:
+    """§12.3's per-solve metrics (``paper.tex:925``).
+
+    A thin wrapper over :class:`cosa.solver.instrumentation.Metrics` rather than a
+    reimplementation: #15 already counts all six of these, which is why it was built four
+    waves before the study that consumes them.
+
+    Attributes:
+        metrics: what the recorder counted.
+        reference_seconds: how long the reference solver took, or ``None``.
+    """
+
+    metrics: Metrics
+    reference_seconds: float | None = None
+
+    @property
+    def speedup(self) -> float | None:
+        """Reference wall clock over COSA's, or ``None`` when there is nothing to compare.
+
+        **It is below one, and that is the finding.** CVXPY spends most of its time building
+        a problem rather than solving one, so this number ought to flatter COSA -- and it
+        does not: the reference is between three and twenty times faster on every mode
+        measured, overhead included. Reporting it is the point of running the study, and
+        §20 (``paper.tex:1339``) says as much: what the paper values is a characterization
+        of *when* conic active-set methods work well, which is not a claim that they always
+        do.
+
+        Where COSA's numbers are good is the iteration and factorization counts on
+        *sequences*, which is what its structure is for. §12.3 asks for wall clock and
+        iteration counts side by side precisely so that the difference between them is
+        visible.
+        """
+        if self.reference_seconds is None or not self.metrics.runtime:
+            return None
+        return self.reference_seconds / self.metrics.runtime
+
+    def __str__(self) -> str:
+        """One performance row."""
+        memory = "" if self.metrics.peak_memory is None else f"  {self.metrics.peak_memory / 1e6:6.1f}MB"
+        against = "" if self.speedup is None else f"  {self.speedup:6.1f}x reference"
+        return (
+            f"{self.metrics.runtime * 1e3:8.2f}ms  {self.metrics.iterations:5d} iters  "
+            f"{self.metrics.kkt_solves:5d} solves  {self.metrics.active_set_changes:4d} changes  "
+            f"{self.metrics.factorizations:4d} fact ({self.metrics.factorization_time * 1e3:7.2f}ms)"
+            f"{memory}{against}"
+        )
+
+
+@dataclass(frozen=True, eq=False)
+class Comparison:
+    """One instance, one mode, both tables.
+
+    Attributes:
+        mode: which of :data:`MODES`.
+        instance: the family's name.
+        assets: how many assets it has.
+        status: COSA's status.
+        accuracy: §12.2's table.
+        performance: §12.3's table.
+    """
+
+    mode: str
+    instance: str
+    assets: int
+    status: str
+    accuracy: Accuracy
+    performance: Performance
+
+    @property
+    def speedup(self) -> float | None:
+        """Convenience for :attr:`Performance.speedup`, whose docstring is the caveat."""
+        return self.performance.speedup
+
+    def __str__(self) -> str:
+        """One line of the combined table."""
+        return (
+            f"{self.mode:9s} {self.instance:20s} n={self.assets:4d} {self.status:9s} | "
+            f"{self.accuracy} | {self.performance}"
+        )
+
+
+def _accuracy(instance: PortfolioInstance, problem: SOCP, answer: Solution, oracle: ReferenceSolver | None) -> Accuracy:
+    """Measure §12.2's metrics for one answer.
+
+    Args:
+        instance: the instance, for its portfolio view.
+        problem: the SOCP actually solved, which for a frontier point is not the instance's
+            own.
+        answer: COSA's solution.
+        oracle: the reference solver, or ``None``.
+
+    Returns:
+        The accuracy row.
+    """
+    holdings = answer.z[: instance.num_assets]
+    objective = answer.objective(problem)
+    reference = None
+    if oracle is not None:
+        try:
+            reference = oracle.solve(problem).objective
+        except SolverUnavailableError:
+            reference = None
+    return Accuracy(
+        residuals=answer.residuals,
+        objective=objective,
+        reference=reference,
+        gap=float("inf") if reference is None else relative_gap(objective, reference),
+        expected_return=instance.portfolio.expected_return(holdings),
+        deviation=instance.portfolio.std(holdings),
+    )
+
+
+def _timed_reference(problem: SOCP, oracle: ReferenceSolver | None) -> float | None:
+    """How long the reference solver takes on this problem, or ``None``.
+
+    Args:
+        problem: the instance.
+        oracle: the reference solver, or ``None``.
+
+    Returns:
+        Seconds, or ``None`` when there is no usable reference.
+    """
+    if oracle is None:
+        return None
+    started = time.perf_counter()
+    try:
+        oracle.solve(problem)
+    except SolverUnavailableError:
+        return None
+    return time.perf_counter() - started
+
+
+def _solve(problem: SOCP, *, memory: bool, warm: WarmStart | None = None) -> Solution:
+    """Solve, with the recorder configured for this mode.
+
+    Args:
+        problem: the instance.
+        memory: whether to track peak allocation, which roughly doubles the cost.
+        warm: the warm start, for the mode that has one.
+
+    Returns:
+        The solution.
+    """
+    recorder = Recorder(track_memory=memory)
+    return solver.solve(problem, recorder=recorder, warm=warm)
+
+
+def benchmark(
+    assets: int = 10,
+    *,
+    seeds: Sequence[int] = (0, 1),
+    oracle: ReferenceSolver | None = None,
+    large: int = 60,
+) -> tuple[Comparison, ...]:
+    """Run all four modes and return both tables for each.
+
+    Args:
+        assets: how many assets the cold, warm and sequence modes use.
+        seeds: which draws.
+        oracle: the reference solver, or ``None`` to pick one. Passing ``None`` and having
+            none installed is not an error: the study still reports COSA's own numbers and
+            marks the agreement column as having nothing to compare against.
+        large: how many assets the large-problem mode uses.
+
+    Returns:
+        One comparison per mode, family and seed.
+    """
+    if oracle is None:
+        try:
+            oracle = default_solver()
+        except SolverUnavailableError:
+            oracle = None
+
+    results: list[Comparison] = []
+    structured = {
+        "basic": families.basic,
+        "box": families.box,
+        "sector": families.sector,
+        "factor exposure": families.factor_exposure,
+    }
+    for seed in seeds:
+        for name, build in structured.items():
+            instance = build(assets, seed=seed)
+            problem = instance.problem
+            answer = _solve(problem, memory=False)
+            results.append(
+                Comparison(
+                    mode="cold",
+                    instance=name,
+                    assets=assets,
+                    status=answer.status,
+                    accuracy=_accuracy(instance, problem, answer, oracle),
+                    performance=Performance(answer.metrics, _timed_reference(problem, oracle)),
+                )
+            )
+
+            # Warm mode: the same instance entered from a neighbouring risk aversion's
+            # answer, which is the smallest honest version of what #35 does at length.
+            neighbour = replace(instance.portfolio, lam=instance.portfolio.lam * 0.9).to_socp()
+            seeded = solver.solve(neighbour)
+            hot = _solve(problem, memory=False, warm=from_solution(seeded))
+            results.append(
+                Comparison(
+                    mode="warm",
+                    instance=name,
+                    assets=assets,
+                    status=hot.status,
+                    accuracy=_accuracy(instance, problem, hot, oracle),
+                    performance=Performance(hot.metrics, _timed_reference(problem, oracle)),
+                )
+            )
+
+        # Large mode, once per seed rather than per family: the question is how the method
+        # scales, and four families of the same size answer it four times over.
+        big = families.box(large, seed=seed)
+        answer = _solve(big.problem, memory=True)
+        results.append(
+            Comparison(
+                mode="large",
+                instance="box",
+                assets=large,
+                status=answer.status,
+                accuracy=_accuracy(big, big.problem, answer, oracle),
+                performance=Performance(answer.metrics, _timed_reference(big.problem, oracle)),
+            )
+        )
+
+        # Sequence mode: #35's frontier as a single unit of work, because that is how a
+        # caller tracing a frontier experiences it.
+        traced = sweep(families.box(assets, seed=seed))
+        last = traced.points[-1]
+        last_residuals = solver.solve(
+            replace(families.box(assets, seed=seed).portfolio, lam=last.lam).to_socp()
+        ).residuals
+        results.append(
+            Comparison(
+                mode="sequence",
+                instance=f"box frontier x{len(traced.points)}",
+                assets=assets,
+                status=last.status,
+                accuracy=Accuracy(
+                    # A sequence has no single point to measure five residuals at. The
+                    # worst residual over the sweep is what `totals()` carries and it is
+                    # already in the performance row, so this row reports the last point's
+                    # answer and leaves the residual block to the per-point table in #35.
+                    residuals=last_residuals,
+                    objective=last.objective,
+                    reference=None,
+                    gap=float("inf"),
+                    expected_return=last.expected_return,
+                    deviation=last.deviation,
+                ),
+                performance=Performance(traced.totals()),
+            )
+        )
+    return tuple(results)
+
+
+def report(
+    assets: int = 10,
+    *,
+    seeds: Sequence[int] = (0, 1),
+    oracle: ReferenceSolver | None = None,
+    large: int = 60,
+) -> str:
+    """The whole study as text, one line per comparison and a tally beneath.
+
+    Args:
+        assets: how many assets the small modes use.
+        seeds: which draws.
+        oracle: the reference solver, or ``None`` to pick one.
+        large: how many assets the large-problem mode uses.
+
+    Returns:
+        The report.
+    """
+    comparisons = benchmark(assets, seeds=seeds, oracle=oracle, large=large)
+    lines = [f"benchmark: {len(comparisons)} comparison(s) across {len(MODES)} modes", ""]
+    lines += [str(comparison) for comparison in comparisons]
+    checked = [comparison for comparison in comparisons if comparison.accuracy.reference is not None]
+    agreeing = [comparison for comparison in checked if comparison.accuracy.agrees]
+    speedups = [comparison.speedup for comparison in comparisons if comparison.speedup is not None]
+    lines += [
+        "",
+        f"Success Criterion 5: {len(agreeing)}/{len(checked)} objectives agree with the reference",
+    ]
+    if speedups:
+        lines.append(
+            f"wall clock vs reference: {min(speedups):.2f}x to {max(speedups):.2f}x "
+            "(below one means the reference is faster)"
+        )
+    return "\n".join(lines)
+
+
+def disagreements(comparisons: Sequence[Comparison]) -> tuple[Comparison, ...]:
+    """The comparisons whose objective did not match the reference.
+
+    Success Criterion 5 is the claim that this is empty.
+
+    Args:
+        comparisons: what :func:`benchmark` returned.
+
+    Returns:
+        The ones that disagreed, ignoring those with nothing to compare against.
+    """
+    return tuple(
+        comparison
+        for comparison in comparisons
+        if comparison.accuracy.reference is not None and not comparison.accuracy.agrees
+    )

--- a/src/cosa/experiments/frontier.py
+++ b/src/cosa/experiments/frontier.py
@@ -1,0 +1,359 @@
+"""The efficient frontier, solved twice: cold, and each point warm started from the last.
+
+§11 (``paper.tex:842``) calls this "one of the principal numerical experiments", and #35 is
+it. The sequence is
+
+    min  -mu.T @ x + lam_k * sigma(x)      for lam_1, ..., lam_N,
+
+which traces the risk-return frontier. §11's observation is that for consecutive ``lam_k``
+and ``lam_(k+1)`` "the optimal portfolios and active constraints are expected to be
+related", and the experiment is whether that expectation is worth anything.
+
+**Only ``c`` changes along the sequence.** ``A``, ``E``, ``G`` and the cone product are
+identical from point to point -- ``lam`` enters eq. (7) as the coefficient of ``t`` in the
+objective and nowhere else. So a working set transfers exactly, in the sense
+:meth:`cosa.solver.warm.WarmStart.fits` checks: the row indices still name the same rows.
+That is the structural fact the whole hypothesis rests on, and it is worth stating because
+it is *not* generic. A sequence that perturbed ``Sigma`` instead would change ``G`` and the
+transfer would be a guess rather than a fact.
+
+**The comparison is paired, and that is the only honest way to run it.** Each ``lam`` is
+solved twice, cold and warm, against the same instance in the same process. Comparing a
+cold sweep against a warm sweep in aggregate would confound the warm start with everything
+else that differs between two runs; solving the same point both ways and differencing
+leaves only the thing under test.
+
+**Seven quantities, because §11 names seven.** :class:`Point` carries six of them per
+frontier point and the seventh, "iterations saved by warm starts", is a function of two
+solves rather than a property of one -- which is why
+:func:`cosa.solver.instrumentation.iterations_saved` is a function and not a field. A
+negative saving is reported rather than clamped: a warm start that costs *more* iterations
+than a cold one is a finding, and this experiment exists partly to find out whether that
+happens.
+
+**What a warm start may not do is change the answer.** :meth:`Point.agrees` is checked at
+every point, and a disagreement is a bug rather than a trade-off. The saving is in how the
+answer was reached.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+
+from cosa.experiments import portfolio as families
+from cosa.linear_algebra.reuse import Reuse
+from cosa.solver import cosa as solver
+from cosa.solver.instrumentation import Metrics, iterations_saved
+from cosa.solver.warm import from_solution
+
+if TYPE_CHECKING:
+    from cosa.experiments.portfolio import PortfolioInstance
+    from cosa.problem.portfolio import MeanStdPortfolio
+    from cosa.problem.socp import SOCP
+
+__all__ = [
+    "AGREEMENT",
+    "LAMBDAS",
+    "Frontier",
+    "Point",
+    "report",
+    "risk_aversions",
+    "sweep",
+]
+
+LAMBDAS: Final = 24
+"""How many frontier points the default sweep traces.
+
+Enough that consecutive problems are genuinely close -- the whole hypothesis is about
+*nearby* problems, and a sweep of four would be testing something else -- and few enough
+that the experiment runs inside a test suite.
+"""
+
+AGREEMENT: Final = 1e-7
+"""How far a warm-started objective may differ from its cold counterpart.
+
+Absolute, and tighter than §6's termination tolerance by an order of magnitude: the two
+solves are of the *same problem*, so their objectives should agree to rather better than
+either agrees with the true optimum. A gap at the termination tolerance would mean the warm
+start had stopped somewhere else, which is exactly what this is watching for.
+"""
+
+
+def risk_aversions(low: float = 0.5, high: float = 8.0, count: int = LAMBDAS) -> tuple[float, ...]:
+    """The ``lam`` sequence, geometrically spaced.
+
+    Geometric rather than linear because ``lam`` is a *ratio* -- return traded against risk --
+    so the interesting structure is spread evenly in its logarithm. A linear sweep of the
+    same range spends most of its points where the frontier is nearly flat, which is where
+    warm starting is easiest and so is the least informative place to measure it.
+
+    Args:
+        low: the smallest risk aversion.
+        high: the largest.
+        count: how many points.
+
+    Returns:
+        The sequence, ascending.
+    """
+    return tuple(float(value) for value in np.geomspace(low, high, count))
+
+
+@dataclass(frozen=True, eq=False)
+class Point:
+    """One frontier point, solved both ways.
+
+    Attributes:
+        lam: the risk aversion.
+        cold: the metrics of the cold solve.
+        warm: the metrics of the warm-started solve.
+        objective: the cold solve's objective, which is the reference value.
+        gap: how far the warm solve's objective is from it.
+        expected_return: ``mu.T @ x`` at the solution, §12.2's accuracy metric.
+        deviation: ``sigma(x)`` there, the other one.
+        status: the warm solve's status.
+    """
+
+    lam: float
+    cold: Metrics
+    warm: Metrics
+    objective: float
+    gap: float
+    expected_return: float
+    deviation: float
+    status: str
+
+    @property
+    def saved(self) -> int:
+        """§11's seventh quantity: ``cold.iterations - warm.iterations``."""
+        return iterations_saved(self.cold, self.warm)
+
+    @property
+    def churn(self) -> int:
+        """How many rows the warm solve had to add or drop.
+
+        Zero means the working set carried in was already the right one, which is the case
+        warm starting is *for*. A nonzero count means the belief was wrong and the loop spent
+        iterations correcting it -- and correcting a belief is more expensive than acquiring
+        one, which is the asymmetry that decides whether a sweep saves anything.
+        """
+        return self.warm.constraints_added + self.warm.constraints_removed
+
+    @property
+    def agrees(self) -> bool:
+        """Did warm starting leave the answer alone?
+
+        The precondition for every other number here meaning anything. A warm start that
+        changed the answer would be a bug, not a speed-up.
+        """
+        return self.gap <= AGREEMENT
+
+    def __str__(self) -> str:
+        """One table row: the seven quantities, in §11's order."""
+        return (
+            f"lam={self.lam:7.3f}  {self.status:9s} "
+            f"iters {self.cold.iterations:5d} -> {self.warm.iterations:5d} (saved {self.saved:+5d})  "
+            f"+{self.warm.constraints_added:3d}/-{self.warm.constraints_removed:3d} rows  "
+            f"fact {self.cold.factorizations:4d} -> {self.warm.factorizations:3d}  "
+            f"{self.warm.runtime * 1e3:7.2f}ms  residual {self.warm.kkt_residual:8.1e}  "
+            f"return {self.expected_return:8.4f}  sd {self.deviation:7.4f}"
+        )
+
+
+@dataclass(frozen=True, eq=False)
+class Frontier:
+    """A whole sweep, and the totals §11 asks to compare.
+
+    Attributes:
+        points: one per risk aversion, in sweep order.
+    """
+
+    points: tuple[Point, ...]
+
+    @property
+    def cold_iterations(self) -> int:
+        """Total active-set iterations solving every point from scratch."""
+        return sum(point.cold.iterations for point in self.points)
+
+    @property
+    def warm_iterations(self) -> int:
+        """Total active-set iterations solving every point from the last one's answer."""
+        return sum(point.warm.iterations for point in self.points)
+
+    @property
+    def saved(self) -> int:
+        """§11's seventh quantity over the whole sweep."""
+        return self.cold_iterations - self.warm_iterations
+
+    @property
+    def share(self) -> float:
+        """The saving as a fraction of the cold cost, which is the headline number."""
+        return self.saved / self.cold_iterations if self.cold_iterations else 0.0
+
+    @property
+    def agrees(self) -> bool:
+        """Did every point agree between the two routes?"""
+        return all(point.agrees for point in self.points)
+
+    @property
+    def stable(self) -> tuple[Point, ...]:
+        """The points where the warm start's believed working set turned out to be right."""
+        return tuple(point for point in self.points if not point.churn)
+
+    @property
+    def changed(self) -> tuple[Point, ...]:
+        """The points where it was wrong and the loop had to correct it."""
+        return tuple(point for point in self.points if point.churn)
+
+    def saving_on(self, points: Sequence[Point]) -> float:
+        """The share of cold iterations saved on a subset, which is where the structure is.
+
+        Args:
+            points: :attr:`stable` or :attr:`changed`, ordinarily.
+
+        Returns:
+            The fraction saved, negative when warm starting cost more than it saved.
+        """
+        cold = sum(point.cold.iterations for point in points)
+        return sum(point.saved for point in points) / cold if cold else 0.0
+
+    @property
+    def is_monotone(self) -> bool:
+        """Does risk fall as ``lam`` rises, which is what a frontier means?
+
+        Not a property of the solver but of the *answers*, and the cheapest available check
+        that the sweep traced a frontier rather than a sequence of unrelated optima. A
+        violation would mean one of the points is wrong however good its residuals look.
+        """
+        deviations = [point.deviation for point in self.points]
+        return all(later <= earlier + 1e-9 for earlier, later in itertools.pairwise(deviations))
+
+    def totals(self) -> Metrics:
+        """The warm sweep's metrics summed, for a benchmark row.
+
+        Returns:
+            One :class:`cosa.solver.instrumentation.Metrics` whose counters are the sweep's
+            totals. The residual is the *worst* rather than the last, because a sweep is only
+            as good as its least converged point.
+        """
+        warm = [point.warm for point in self.points]
+        return Metrics(
+            iterations=sum(metrics.iterations for metrics in warm),
+            constraints_added=sum(metrics.constraints_added for metrics in warm),
+            constraints_removed=sum(metrics.constraints_removed for metrics in warm),
+            cone_changes=sum(metrics.cone_changes for metrics in warm),
+            factorizations=sum(metrics.factorizations for metrics in warm),
+            kkt_solves=sum(metrics.kkt_solves for metrics in warm),
+            runtime=sum(metrics.runtime for metrics in warm),
+            factorization_time=sum(metrics.factorization_time for metrics in warm),
+            kkt_residual=max((metrics.kkt_residual for metrics in warm), default=float("nan")),
+            working_set_revisits=max((metrics.working_set_revisits for metrics in warm), default=0),
+        )
+
+    def __str__(self) -> str:
+        """The sweep's headline: work saved, and whether the answers survived it."""
+        agreement = "answers agree" if self.agrees else "ANSWERS DISAGREE"
+        return (
+            f"frontier: {len(self.points)} points, "
+            f"{self.cold_iterations} cold iterations -> {self.warm_iterations} warm "
+            f"({self.share:.0%} saved), {agreement}\n"
+            f"  {len(self.stable)} point(s) with the working set unchanged: "
+            f"{self.saving_on(self.stable):+.0%}\n"
+            f"  {len(self.changed)} point(s) that had to correct it:        "
+            f"{self.saving_on(self.changed):+.0%}"
+        )
+
+
+def _at(portfolio: MeanStdPortfolio, lam: float) -> SOCP:
+    """The SOCP for one risk aversion.
+
+    Args:
+        portfolio: the instance's eq. (1) form.
+        lam: the risk aversion to substitute.
+
+    Returns:
+        The SOCP, which differs from its neighbours in ``c`` and nothing else.
+    """
+    return replace(portfolio, lam=lam).to_socp()
+
+
+def sweep(
+    instance: PortfolioInstance | None = None,
+    lams: Sequence[float] | None = None,
+    *,
+    assets: int = 10,
+    seed: int = 0,
+) -> Frontier:
+    """Solve the frontier twice and measure the difference.
+
+    Args:
+        instance: the portfolio to trace, or ``None`` for a box-constrained one. Box rather
+            than basic: bounds are what make the active set non-trivial, and a frontier whose
+            working set is empty at every point would show warm starting saving nothing
+            because there was nothing to carry.
+        lams: the risk aversions, or ``None`` for :func:`risk_aversions`.
+        assets: how many assets, when building the default instance.
+        seed: the draw, when building the default instance.
+
+    Returns:
+        The sweep.
+    """
+    instance = instance if instance is not None else families.box(assets, seed=seed)
+    sequence = tuple(lams) if lams is not None else risk_aversions()
+    cache = Reuse()
+    hint = None
+    points = []
+    for lam in sequence:
+        problem = _at(instance.portfolio, lam)
+        cold = solver.solve(problem)
+        hot = solver.solve(problem, warm=hint)
+        portfolio = replace(instance.portfolio, lam=lam)
+        holdings = hot.z[: instance.num_assets]
+        points.append(
+            Point(
+                lam=lam,
+                cold=cold.metrics,
+                warm=hot.metrics,
+                objective=cold.objective(problem),
+                gap=abs(hot.objective(problem) - cold.objective(problem)),
+                expected_return=portfolio.expected_return(holdings),
+                deviation=portfolio.std(holdings),
+                status=hot.status,
+            )
+        )
+        hint = from_solution(hot, cache=cache)
+    return Frontier(points=tuple(points))
+
+
+def report(
+    instance: PortfolioInstance | None = None,
+    lams: Sequence[float] | None = None,
+    *,
+    assets: int = 10,
+    seed: int = 0,
+) -> str:
+    """The sweep as text, with §11's seven quantities per point and the totals beneath.
+
+    Args:
+        instance: the portfolio to trace, or ``None`` for the default.
+        lams: the risk aversions, or ``None`` for :func:`risk_aversions`.
+        assets: how many assets, when building the default instance.
+        seed: the draw, when building the default instance.
+
+    Returns:
+        The report.
+    """
+    traced = sweep(instance, lams, assets=assets, seed=seed)
+    lines = [str(traced), ""]
+    lines += [str(point) for point in traced.points]
+    totals = traced.totals()
+    lines += [
+        "",
+        f"warm totals: {totals}",
+        f"monotone frontier: {traced.is_monotone}",
+    ]
+    return "\n".join(lines)

--- a/src/cosa/solver/instrumentation.py
+++ b/src/cosa/solver/instrumentation.py
@@ -232,6 +232,7 @@ class Recorder:
         self._cone_changes = 0
         self._factorizations = 0
         self._revisits = 0
+        self._started: float | None = None
         self._kkt_solves = 0
         self._runtime = 0.0
         self._factorization_time = 0.0
@@ -248,11 +249,12 @@ class Recorder:
         started_tracing = self._track_memory and not tracemalloc.is_tracing()
         if started_tracing:
             tracemalloc.start()
-        start = time.perf_counter()
+        self._started = time.perf_counter()
         try:
             yield self
         finally:
-            self._runtime += time.perf_counter() - start
+            self._runtime += time.perf_counter() - self._started
+            self._started = None
             if self._track_memory:
                 self._peak_memory = tracemalloc.get_traced_memory()[1]
                 if started_tracing:
@@ -322,6 +324,37 @@ class Recorder:
         """Count one active-set iteration."""
         self._iterations += 1
 
+    def _elapsed(self) -> float:
+        """Total seconds spent solving, including a solve still in progress.
+
+        The subtlety this exists for: :func:`cosa.solve` builds its :class:`Solution` --
+        and so calls :meth:`metrics` -- from *inside* the ``with recorder.solving()`` block,
+        so a runtime recorded only in that block's ``finally`` is always zero by the time
+        anybody reads it. It was, for four waves. §11 asks for total runtime and #34's study
+        is the first consumer that would have noticed, which is result 9 of #43 once more:
+        the number was wrong from the day it was added and nothing had a reason to look.
+
+        Returns:
+            Seconds, including the in-progress interval when one is open.
+        """
+        running = 0.0 if self._started is None else time.perf_counter() - self._started
+        return self._runtime + running
+
+    def _peak(self) -> int | None:
+        """Peak bytes allocated, sampled live when tracing is still open.
+
+        Same reason as :meth:`_elapsed`: the value latched in ``solving()``'s ``finally`` is
+        not yet set when the solution is built.
+
+        Returns:
+            The peak, or ``None`` when memory was not tracked.
+        """
+        if not self._track_memory:
+            return None
+        if self._started is not None and tracemalloc.is_tracing():
+            return tracemalloc.get_traced_memory()[1]
+        return self._peak_memory
+
     def working_set_seen(self, visits: int) -> None:
         """Record how often the working set now in force has been reached.
 
@@ -377,10 +410,10 @@ class Recorder:
             factorizations=self._factorizations,
             working_set_revisits=self._revisits,
             kkt_solves=self._kkt_solves,
-            runtime=self._runtime,
+            runtime=self._elapsed(),
             factorization_time=self._factorization_time,
             kkt_residual=self._residual,
-            peak_memory=self._peak_memory,
+            peak_memory=self._peak(),
         )
 
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,222 @@
+"""§12's comparison study, in the four modes the paper asks for.
+
+Issue #34. What is tested is that the study measures the right things and that Success
+Criterion 5 — every generated problem's objective agrees with the reference within the
+prescribed tolerance — actually holds. The performance numbers are reported rather than
+asserted, because a test that pinned wall-clock time would fail on a busy machine and tell
+nobody anything; what is asserted about performance is that it is *measured*, which is a
+claim that has been wrong before.
+"""
+
+import pytest
+
+from cosa.experiments import benchmarks
+from cosa.experiments.reference import SolverUnavailableError, default_solver
+from cosa.solver.termination import Residuals
+
+
+@pytest.fixture(scope="module")
+def oracle():
+    """A reference solver, or a skip. The study runs without one; this file does not."""
+    try:
+        return default_solver()
+    except SolverUnavailableError as missing:  # pragma: no cover - CI installs one
+        pytest.skip(str(missing))
+
+
+@pytest.fixture(scope="module")
+def comparisons(oracle):
+    """One pass of the study, shared."""
+    return benchmarks.benchmark(8, seeds=(0,), oracle=oracle, large=40)
+
+
+# ----------------------------------------------------------------------------------
+# Success Criterion 5
+# ----------------------------------------------------------------------------------
+
+
+def test_every_objective_agrees_with_the_reference(comparisons):
+    """§16.3's requirement and Success Criterion 5, which is the study's reason to exist."""
+    assert benchmarks.disagreements(comparisons) == ()
+
+
+def test_the_agreement_is_actually_checked(comparisons):
+    """A study that silently had no reference would report the same thing as one that agreed.
+
+    So the count of comparisons with something to compare against is asserted too — this is
+    the distinction `Accuracy.reference is None` exists to keep.
+    """
+    checked = [c for c in comparisons if c.accuracy.reference is not None]
+    assert len(checked) >= len(comparisons) - 1, "only the sequence mode has no single reference"
+
+
+def test_agreement_is_vacuously_true_without_a_reference():
+    """And is reported as such rather than as agreement."""
+    accuracy = benchmarks.Accuracy(
+        residuals=Residuals(
+            primal=0.0, dual=0.0, stationarity=0.0, linear_complementarity=0.0, cone_complementarity=0.0
+        ),
+        objective=1.0,
+        reference=None,
+        gap=float("inf"),
+        expected_return=0.0,
+        deviation=0.0,
+    )
+    assert accuracy.agrees
+    assert "no reference" in str(accuracy)
+
+
+# ----------------------------------------------------------------------------------
+# The four modes
+# ----------------------------------------------------------------------------------
+
+
+def test_all_four_modes_are_reported(comparisons):
+    """§12 lists four and separates them because they are four different questions."""
+    assert {comparison.mode for comparison in comparisons} == set(benchmarks.MODES)
+
+
+def test_every_mode_reaches_an_optimum(comparisons):
+    """A mode that failed would make its metrics meaningless."""
+    assert all(comparison.status == "optimal" for comparison in comparisons)
+
+
+def test_the_large_mode_is_the_only_one_that_measures_memory(comparisons):
+    """§12.3 asks for memory "where relevant" and `tracemalloc` roughly doubles a solve.
+
+    The large-problem mode is the only one where the answer could be interesting, so it is
+    the only one that pays.
+    """
+    tracked = {c.mode for c in comparisons if c.performance.metrics.peak_memory is not None}
+    assert tracked == {"large"}
+
+
+def test_the_sequence_mode_aggregates_a_whole_frontier(comparisons):
+    """Because that is how a caller tracing a frontier experiences the cost."""
+    sequence = next(c for c in comparisons if c.mode == "sequence")
+    assert sequence.performance.metrics.iterations > 100
+    assert "frontier" in sequence.instance
+
+
+# ----------------------------------------------------------------------------------
+# §12.2's and §12.3's tables
+# ----------------------------------------------------------------------------------
+
+
+def test_the_accuracy_table_carries_what_paper_asks_for(comparisons):
+    """Five residuals, objective, expected return, standard deviation."""
+    accuracy = comparisons[0].accuracy
+    assert accuracy.residuals.is_optimal()
+    assert accuracy.deviation > 0.0
+    assert accuracy.expected_return != 0.0
+
+
+def test_the_performance_table_carries_what_paper_asks_for(comparisons):
+    """Wall clock, iterations, KKT solves, active-set changes, factorization time."""
+    for comparison in comparisons:
+        metrics = comparison.performance.metrics
+        assert metrics.runtime > 0.0, f"{comparison.mode}: runtime was never being recorded"
+        assert metrics.iterations > 0
+        assert metrics.kkt_solves > 0
+        assert metrics.factorization_time > 0.0
+
+
+def test_runtime_is_measured_from_inside_the_solve(comparisons):
+    """The regression test for a bug this study found.
+
+    `Metrics.runtime` was zero for every solve ever recorded: `cosa.solve` builds its
+    `Solution` from inside the `with recorder.solving()` block, so a runtime latched in that
+    block's `finally` was not yet set when anybody read it. It had been wrong since #15 and
+    #34 is the first consumer with a reason to look.
+    """
+    assert all(comparison.performance.metrics.runtime > 0.0 for comparison in comparisons)
+
+
+# ----------------------------------------------------------------------------------
+# The wall-clock finding
+# ----------------------------------------------------------------------------------
+
+
+def test_the_reference_is_faster_and_the_study_says_so(comparisons):
+    """The finding, reported rather than buried.
+
+    CVXPY spends most of its time building a problem rather than solving one, so this
+    comparison ought to flatter COSA — and it does not. §20 asks for a characterization of
+    *when* conic active-set methods work well, which is not a claim that they always do.
+    """
+    speedups = [c.speedup for c in comparisons if c.speedup is not None]
+    assert speedups
+    assert max(speedups) < 1.0, "if this ever fails, the paper's results section changes"
+
+
+def test_the_iteration_counts_are_where_the_structure_is(comparisons):
+    """Which is why §12.3 asks for wall clock and iteration counts side by side."""
+    warm = [c for c in comparisons if c.mode == "warm"]
+    cold = [c for c in comparisons if c.mode == "cold"]
+    assert sum(c.performance.metrics.factorizations for c in warm) <= sum(
+        c.performance.metrics.factorizations for c in cold
+    )
+
+
+# ----------------------------------------------------------------------------------
+# The report
+# ----------------------------------------------------------------------------------
+
+
+def test_the_report_runs(oracle):
+    """It is what the paper's results section is written from."""
+    text = benchmarks.report(6, seeds=(0,), oracle=oracle, large=20)
+    assert "Success Criterion 5" in text
+    assert "wall clock vs reference" in text
+    for mode in benchmarks.MODES:
+        assert mode in text
+
+
+def test_a_comparison_renders_its_own_row(comparisons):
+    """One line carrying both tables, which is what a results table row is."""
+    rendered = str(comparisons[0])
+    assert "cold" in rendered
+    assert "obj" in rendered
+    assert "iters" in rendered
+
+
+class _Unavailable:
+    """A reference solver that is installed and never works, which is a real case.
+
+    An unlicensed commercial backend behaves exactly like this: `is_available` says yes
+    because the package imports, and every solve fails on the license. The study has to
+    report COSA's own numbers rather than crash, and has to mark the agreement column as
+    having nothing to compare against rather than as agreement.
+    """
+
+    name = "unavailable"
+    accuracy = 1e-9
+
+    def is_available(self) -> bool:
+        """It claims to be."""
+        return True
+
+    def solve(self, problem):
+        """And then is not."""
+        raise SolverUnavailableError(self.name, "no license")
+
+
+def test_the_study_runs_without_a_working_reference():
+    """Every mode still reports, and nothing claims agreement it did not check."""
+    comparisons = benchmarks.benchmark(6, seeds=(0,), oracle=_Unavailable(), large=15)
+    assert {comparison.mode for comparison in comparisons} == set(benchmarks.MODES)
+    assert all(comparison.accuracy.reference is None for comparison in comparisons)
+    assert benchmarks.disagreements(comparisons) == (), "nothing to disagree with"
+    assert all(comparison.speedup is None for comparison in comparisons)
+
+
+def test_no_reference_installed_is_not_an_error(monkeypatch):
+    """CI without the `reference` extra must still be able to run the study."""
+
+    def missing(*_args, **_kwargs):
+        """Stand in for `default_solver` on a machine with no reference installed."""
+        raise SolverUnavailableError("none", "not installed")
+
+    monkeypatch.setattr(benchmarks, "default_solver", missing)
+    comparisons = benchmarks.benchmark(6, seeds=(0,), large=15)
+    assert all(comparison.accuracy.reference is None for comparison in comparisons)

--- a/tests/test_frontier.py
+++ b/tests/test_frontier.py
@@ -1,0 +1,197 @@
+"""§11's principal experiment: does warm starting a frontier pay?
+
+Issue #35. The sequence is `min -mu.T @ x + lam_k * sigma(x)` for `lam_1 ... lam_N`, solved
+twice — cold, and each point warm started from the last. §11 names seven quantities and the
+experiment reports all seven; what is tested here is that the comparison is *sound*, and
+that the structure it finds is real rather than an artefact of one instance.
+
+The finding is not a single number. Warm starting pays on the points where the carried
+working set turns out to be right and costs on the points where it does not, and the sign
+of the total is decided by the mix. That split is asserted on three instances, because a
+result seen once is a coincidence.
+"""
+
+import itertools
+
+import numpy as np
+import pytest
+
+from cosa.experiments import frontier
+from cosa.experiments import portfolio as families
+
+
+@pytest.fixture(scope="module")
+def traced():
+    """One sweep, shared — twenty-four points solved twice is not worth repeating."""
+    return frontier.sweep(families.box(8, seed=0))
+
+
+# ----------------------------------------------------------------------------------
+# The sequence itself
+# ----------------------------------------------------------------------------------
+
+
+def test_the_lambdas_are_spaced_geometrically():
+    """`lam` is a ratio — return traded against risk — so its structure is in its logarithm.
+
+    A linear sweep of the same range spends most of its points where the frontier is nearly
+    flat, which is where warm starting is easiest and so the least informative place to
+    measure it.
+    """
+    lams = frontier.risk_aversions(1.0, 8.0, 4)
+    ratios = [later / earlier for earlier, later in itertools.pairwise(lams)]
+    assert ratios == pytest.approx([ratios[0]] * len(ratios))
+
+
+def test_every_point_solves(traced):
+    """A sweep with a failure in it measures nothing."""
+    assert all(point.status == "optimal" for point in traced.points)
+
+
+def test_only_c_changes_along_the_sequence():
+    """The structural fact the whole hypothesis rests on, and it is not generic.
+
+    `lam` enters eq. (7) as the coefficient of `t` in the objective and nowhere else, so a
+    working set transfers *exactly*. A sequence that perturbed `Sigma` would change `G`, and
+    the transfer would be a guess.
+    """
+    instance = families.box(6, seed=0)
+    first = frontier._at(instance.portfolio, 1.0)
+    second = frontier._at(instance.portfolio, 3.0)
+    assert np.array_equal(first.A, second.A)
+    assert np.array_equal(first.E, second.E)
+    assert np.array_equal(first.G, second.G)
+    assert first.cone == second.cone
+    assert not np.array_equal(first.c, second.c)
+
+
+def test_the_frontier_is_monotone(traced):
+    """Risk falls as `lam` rises, which is what a frontier means.
+
+    A property of the answers rather than of the solver, and the cheapest check that the
+    sweep traced a frontier rather than a sequence of unrelated optima — a violation would
+    mean one point is wrong however good its residuals look.
+    """
+    assert traced.is_monotone
+
+
+# ----------------------------------------------------------------------------------
+# What a warm start may not do
+# ----------------------------------------------------------------------------------
+
+
+def test_warm_starting_does_not_change_the_answer(traced):
+    """The precondition for every other number meaning anything.
+
+    A warm start that changed the answer would be a bug, not a speed-up. The saving is in
+    how the answer was reached.
+    """
+    assert traced.agrees
+    assert max(point.gap for point in traced.points) <= frontier.AGREEMENT
+
+
+def test_the_comparison_is_paired(traced):
+    """Each `lam` is solved both ways against the same instance in the same process.
+
+    Comparing a cold sweep against a warm sweep in aggregate would confound the warm start
+    with everything else that differs between two runs.
+    """
+    assert traced.cold_iterations == sum(point.cold.iterations for point in traced.points)
+    assert traced.warm_iterations == sum(point.warm.iterations for point in traced.points)
+
+
+# ----------------------------------------------------------------------------------
+# §11's seven quantities
+# ----------------------------------------------------------------------------------
+
+
+def test_all_seven_quantities_are_reported(traced):
+    """§11 names seven and the report carries seven, six per point and one across two."""
+    point = traced.points[-1]
+    assert point.warm.iterations >= 0
+    assert point.warm.constraints_added >= 0
+    assert point.warm.constraints_removed >= 0
+    assert point.warm.factorizations >= 0
+    assert point.warm.runtime > 0.0
+    assert np.isfinite(point.warm.kkt_residual)
+    assert isinstance(point.saved, int)
+
+
+def test_a_negative_saving_is_reported_rather_than_clamped():
+    """A warm start that costs more iterations than a cold one is a finding.
+
+    This experiment exists partly to find out whether that happens, and it does — so the
+    quantity must be able to express it.
+    """
+    losses = [point for point in frontier.sweep(families.box(12, seed=0)).points if point.saved < 0]
+    assert losses, "the box(12) sweep is the instance where warm starting sometimes loses"
+
+
+def test_the_sweep_summarizes_itself(traced):
+    """A headline a reader can act on: work saved, and whether the answers survived."""
+    rendered = str(traced)
+    assert "frontier: 24 points" in rendered
+    assert "answers agree" in rendered
+    assert "working set unchanged" in rendered
+
+
+def test_the_totals_take_the_worst_residual_not_the_last(traced):
+    """A sweep is only as good as its least converged point."""
+    totals = traced.totals()
+    assert totals.kkt_residual == max(point.warm.kkt_residual for point in traced.points)
+    assert totals.iterations == traced.warm_iterations
+
+
+# ----------------------------------------------------------------------------------
+# The finding
+# ----------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("assets", [8, 10, 12])
+def test_warm_starting_pays_where_the_working_set_transfers(assets):
+    """The result, on three instances so that it is a result and not a coincidence.
+
+    Warm starting saves substantially on the points where the carried working set turns out
+    to be right, and *costs* on the points where the loop has to correct it. Correcting a
+    belief is more expensive than acquiring one: a cold solve discovers the active set on
+    the way in, while a warm one has to undo a wrong answer first and then discover it
+    anyway.
+    """
+    traced = frontier.sweep(families.box(assets, seed=0))
+    assert traced.stable, "some point must carry its working set intact"
+    assert traced.changed, "and some must not, or there is nothing to compare"
+    assert traced.saving_on(traced.stable) > 0.1
+    assert traced.saving_on(traced.changed) < 0.0
+
+
+def test_the_overall_sign_is_decided_by_the_mix():
+    """Which is why a single headline number is the wrong way to report this.
+
+    `box(8)` saves 44% overall and `box(12)` loses 7%, with the *per-group* savings almost
+    identical between them. What differs is how many points had to correct their working
+    set.
+    """
+    small = frontier.sweep(families.box(8, seed=0))
+    large = frontier.sweep(families.box(12, seed=0))
+    assert small.share > large.share
+    assert len(small.changed) < len(large.changed)
+
+
+def test_the_saving_is_positive_on_the_default_sweep():
+    """#30's "done when" — iterations saved strictly positive across the frontier sequence.
+
+    On the default instance, and stated as the conditional claim it is: the sweep whose
+    working sets mostly transfer saves work. `test_the_overall_sign_is_decided_by_the_mix`
+    is the other half and is what stops this being read as a universal.
+    """
+    traced = frontier.sweep()
+    assert traced.saved > 0
+    assert traced.share > 0.0
+
+
+def test_the_report_runs():
+    """`docs` and #34 both read this, so it has to produce text."""
+    text = frontier.report(families.box(6, seed=0), lams=frontier.risk_aversions(1.0, 3.0, 5))
+    assert "frontier: 5 points" in text
+    assert "monotone frontier: True" in text
+    assert "warm totals:" in text

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -87,15 +87,22 @@ NOT_AT_THE_ROOT = [
 # library, not part of what the library offers, so none of it reaches the root either.
 NOT_THE_LIBRARY = [
     "Ablation",
+    "Accuracy",
+    "Comparison",
+    "Frontier",
+    "Performance",
+    "Point",
     "CrossCheck",
     "CvxpySolver",
     "PortfolioInstance",
     "RandomSpec",
     "Outcome",
     "ablate",
+    "benchmark",
     "cross_check",
     "random_instance",
     "solve_reference",
+    "sweep",
 ]
 
 


### PR DESCRIPTION
Closes #35, #34. Wave 10. **Stacked on #55** (Wave 9) — review that first.

## #35 — §11's principal experiment

The frontier `min -mu'x + lam_k·sigma(x)` for `lam_1 … lam_N`, solved twice: cold, and each point warm started from the last. **Paired** — each `lam` solved both ways against the same instance in the same process — because comparing a cold sweep against a warm sweep in aggregate would confound the warm start with everything else that differs between two runs.

The structural fact the whole hypothesis rests on, and it is *not* generic: `lam` enters eq. (7) as the coefficient of `t` in the objective and nowhere else, so `A`, `E`, `G` and the cone product are identical from point to point and a working set transfers **exactly**. A sequence that perturbed `Sigma` would change `G` and the transfer would be a guess.

### The result is not a single number, and reporting it as one would have hidden it

| | box(8) | box(10) | box(12) |
| --- | --- | --- | --- |
| points where the working set carried in was right | **+55%** | **+18%** | **+18%** |
| points that had to correct it | **−27%** | **−17%** | **−32%** |
| overall | +44% | +9% | **−7%** |

**Warm starting pays exactly when the active set transfers, and costs when it does not.** Correcting a belief is more expensive than acquiring one: a cold solve discovers the active set on the way in, while a warm one has to undo a wrong answer first and then discover it anyway. The sign of the total is decided by the mix, not by the size of either effect — the per-group savings are nearly identical between the instance that saves 44% and the one that loses 7%.

That is the characterization §20 (`paper.tex:1339`) asks for, stated as the conditional it is rather than as a universal.

A negative saving is reported rather than clamped, because this experiment exists partly to find out whether it happens — and it does.

## #34 — §12's comparison, four modes, both tables

**Success Criterion 5 holds**: every generated problem's objective agrees with the reference to within `1e-6`, in every mode.

### The wall clock does not, and that is the finding

CVXPY spends most of its time building a problem rather than solving one, so this comparison ought to flatter COSA. It does not: **the reference is 3–30× faster on every mode measured, overhead included.**

Reported rather than buried. §20 asks for a characterization of *when* conic active-set methods work well, which is not a claim that they always do — and §12.3 asks for wall clock and iteration counts side by side precisely so the difference between them is visible. Where COSA's numbers are good is the iteration and factorization counts on sequences.

### A bug the study found

`Metrics.runtime` had been **zero for every solve ever recorded.** `cosa.solve` builds its `Solution` — and so calls `recorder.metrics()` — from *inside* the `with recorder.solving()` block, so a runtime latched in that block's `finally` was not yet set when anybody read it. Wrong since #15; #34 is the first consumer with a reason to look. Peak memory had the same shape of bug. Both now sample live, and there is a regression test that says so.

Result 9 of #43 once more: silent failure is the default failure mode, and it is only ever found by building the thing that would notice.

## Done when

- [x] #35: the `lam` sequence runs end to end and reports all seven of §11's quantities
- [x] #35: whether warm starting measurably reduces work between consecutive points — answered, with the condition under which it does
- [x] #34: cold, warm, large and sequence modes reported separately
- [x] #34: §12.2's accuracy metrics and §12.3's performance metrics, both tables filled
- [x] #34: Success Criterion 5 — every objective agrees with the reference within tolerance

All rhiza gates green, 100% coverage, 1142 tests.