### PR TITLE
build: mark cosa Private :: Do Not Upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,17 @@
 license = "MIT"
 license-files = ["LICENSE"]
 classifiers = [
+    # Not a PyPI-registered classifier but a recognised convention, and load-bearing
+    # here: rhiza_release.yml's "Check if dist contains artifacts and not marked as
+    # private" step greps pyproject.toml for this exact string and skips the PyPI
+    # publish job when it is present.
+    #
+    # Without it, pushing a vX.Y.Z tag would fire a real release and attempt to publish
+    # `cosa` to PyPI -- a name already held by an unrelated project (latest 0.4), so the
+    # upload would fail after the GitHub release had been cut. This repo has no tags
+    # older than v0.1.0 and has never published, so opting out is the accurate statement,
+    # not a restriction.
+    "Private :: Do Not Upload",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
Adds the `Private :: Do Not Upload` classifier, which cosa was the only one of these repos to lack.

## Why it matters here

`rhiza_release.yml`'s *Check if dist contains artifacts and not marked as private* step greps `pyproject.toml` for this exact string and skips the PyPI publish job when it is present. Without it, pushing a `vX.Y.Z` tag fires a real release and **attempts to publish to PyPI**.

The name `cosa` on PyPI is already held by an unrelated project (latest 0.4, a different author), so the upload would have failed — but only *after* the GitHub release was cut and attestations generated.

This repo has never published and had no tags at all before `v0.1.0`, so declaring it private states what is already true rather than imposing a new restriction.

## This unblocks the `v0.1.0` tag

hatch-vcs (added in #65) needs a tag visible to CI to derive a real version — without one it silently builds `0.1.dev1+g<sha>`. The tag could not safely be pushed while a tag push meant a publish attempt. With this merged, it can.

## Scope

| Repo | Classifier | Why |
|---|---|---|
| cosa | **added here** | never published; name taken by another project |
| cs, cvxball, proximal | already present | unpublished |
| pyhrp, jsharpe, TinyCTA | deliberately absent | genuinely published to PyPI under the maintainer's own name — these must keep publishing |
